### PR TITLE
gdk_display_supports_composite() has been deprecated since version 3.16

### DIFF
--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -590,12 +590,6 @@ func (v *Display) SupportsInputShapes() bool {
 	return gobool(c)
 }
 
-// SupportsComposite() is a wrapper around gdk_display_supports_composite().
-func (v *Display) SupportsComposite() bool {
-	c := C.gdk_display_supports_composite(v.native())
-	return gobool(c)
-}
-
 // TODO(jrick) glib.AppLaunchContext GdkAppLaunchContext
 func (v *Display) GetAppLaunchContext() {
 }

--- a/gtk/gtk_deprecated_since_3_16.go
+++ b/gtk/gtk_deprecated_since_3_16.go
@@ -29,3 +29,9 @@ func (v *Widget) OverrideFont(description string) {
 	c := C.pango_font_description_from_string(cstr)
 	C.gtk_widget_override_font(v.native(), c)
 }
+
+// SupportsComposite() is a wrapper around gdk_display_supports_composite().
+func (v *Display) SupportsComposite() bool {
+	c := C.gdk_display_supports_composite(v.native())
+	return gobool(c)
+}


### PR DESCRIPTION
https://developer.gnome.org/gdk3/stable/GdkDisplay.html#gdk-display-supports-composite