### PR TITLE
Makes wrapObject use the appropriate ref increasing method

### DIFF
--- a/glib/glib.go
+++ b/glib/glib.go
@@ -1270,7 +1270,9 @@ func (v *Value) GoValue() (interface{}, error) {
 	rv, err := f(uintptr(unsafe.Pointer(v.native())))
 	if obj, ok := rv.(IObject); ok {
 		o := obj.toObject()
-		o.RefSink()
+		o.Ref()
+		//How could this marshall a floating object? Is it supposed to instantiate gobjects?
+		//o.RefSink()
 		runtime.SetFinalizer(o, (*Object).Unref)
 	}
 	return rv, err


### PR DESCRIPTION
Although `RefSink` behaves like `Ref` for non floating objects, we should only sink references on floating objects.

Thoughts?