### PR TITLE
gtk.go, gtk.h: Pass correct GObject type to gtk.TreeStore.SetValue().

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -9130,13 +9130,21 @@ func (v *TreeStore) Append(parent *TreeIter) *TreeIter {
 
 // SetValue is a wrapper around gtk_tree_store_set_value()
 func (v *TreeStore) SetValue(iter *TreeIter, column int, value interface{}) error {
-	gv, err := glib.GValue(value)
-	if err != nil {
-		return err
+	switch value.(type) {
+	case *gdk.Pixbuf:
+		pix := value.(*gdk.Pixbuf)
+		C._gtk_tree_store_set(v.native(), iter.native(),
+			C.gint(column), unsafe.Pointer(pix.Native()))
+
+	default:
+		gv, err := glib.GValue(value)
+		if err != nil {
+			return err
+		}
+		C.gtk_tree_store_set_value(v.native(), iter.native(),
+			C.gint(column),
+			(*C.GValue)(C.gpointer(gv.Native())))
 	}
-	C.gtk_tree_store_set_value(v.native(), iter.native(),
-		C.gint(column),
-		(*C.GValue)(C.gpointer(gv.Native())))
 	return nil
 }
 

--- a/gtk/gtk.go.h
+++ b/gtk/gtk.go.h
@@ -647,6 +647,13 @@ _gtk_list_store_set(GtkListStore *list_store, GtkTreeIter *iter, gint column,
 	gtk_list_store_set(list_store, iter, column, value, -1);
 }
 
+static void
+_gtk_tree_store_set(GtkTreeStore *tree_store, GtkTreeIter *iter, gint column,
+	void* value)
+{
+	gtk_tree_store_set(tree_store, iter, column, value, -1);
+}
+
 static GtkWidget *
 _gtk_message_dialog_new(GtkWindow *parent, GtkDialogFlags flags,
     GtkMessageType type, GtkButtonsType buttons, char *msg)


### PR DESCRIPTION
Fix for issue #45: apply the same method as used for gtk.ListStore, to pass gdk.Pixbuf objects to
gtk.TreeStore.