### PR TITLE
Added GtkHeaderBar to WrapFn

### DIFF
--- a/gtk/gtk_since_3_10.go
+++ b/gtk/gtk_since_3_10.go
@@ -54,6 +54,7 @@ func init() {
 
 	//Contribute to casting
 	for k, v := range map[string]WrapFn{
+		"GtkHeaderBar":     wrapHeaderBar,
 		"GtkListBox":       wrapListBox,
 		"GtkListBoxRow":    wrapListBoxRow,
 		"GtkRevealer":      wrapRevealer,


### PR DESCRIPTION
Using builder.GetObject() with a GtkHeaderBar causes a error because GtkHeaderBar's wrap function was not added to WrapFn.