### PR TITLE
Wrap glib.List elements

### DIFF
--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -449,7 +449,13 @@ func (v *DeviceManager) GetDisplay() (*Display, error) {
 // ListDevices() is a wrapper around gdk_device_manager_list_devices().
 func (v *DeviceManager) ListDevices(tp DeviceType) *glib.List {
 	clist := C.gdk_device_manager_list_devices(v.native(), C.GdkDeviceType(tp))
+	if clist == nil {
+		return nil
+	}
 	glist := glib.WrapList(uintptr(unsafe.Pointer(clist)))
+	glist.DataWrapper(func(ptr unsafe.Pointer) interface{} {
+		return &Device{&glib.Object{glib.ToGObject(ptr)}}
+	})
 	runtime.SetFinalizer(glist, func(glist *glib.List) {
 		glist.Free()
 	})

--- a/glib/list.go
+++ b/glib/list.go
@@ -14,6 +14,10 @@ import "unsafe"
 // List is a representation of Glib's GList.
 type List struct {
 	list *C.struct__GList
+	// If set, dataWrap is called every time NthDataWrapped()
+	// or DataWrapped() is called to wrap raw underlying
+	// value into appropriate type.
+	dataWrap func(unsafe.Pointer) interface{}
 }
 
 func WrapList(obj uintptr) *List {
@@ -21,7 +25,14 @@ func WrapList(obj uintptr) *List {
 }
 
 func wrapList(obj *C.struct__GList) *List {
-	return &List{obj}
+	return &List{list: obj}
+}
+
+func (v *List) wrapNewHead(obj *C.struct__GList) *List {
+	return &List{
+		list:     obj,
+		dataWrap: v.dataWrap,
+	}
 }
 
 func (v *List) Native() uintptr {
@@ -35,22 +46,29 @@ func (v *List) native() *C.struct__GList {
 	return v.list
 }
 
+// DataWapper sets wrap functions, which is called during NthDataWrapped()
+// and DataWrapped(). It's used to cast raw C data into appropriate
+// Go structures and types every time that data is retreived.
+func (v *List) DataWrapper(fn func(unsafe.Pointer) interface{}) {
+	v.dataWrap = fn
+}
+
 // Append is a wrapper around g_list_append().
 func (v *List) Append(data uintptr) *List {
 	glist := C.g_list_append(v.native(), C.gpointer(data))
-	return wrapList(glist)
+	return v.wrapNewHead(glist)
 }
 
 // Prepend is a wrapper around g_list_prepend().
 func (v *List) Prepend(data uintptr) *List {
 	glist := C.g_list_prepend(v.native(), C.gpointer(data))
-	return wrapList(glist)
+	return v.wrapNewHead(glist)
 }
 
 // Insert is a wrapper around g_list_insert().
 func (v *List) Insert(data uintptr, position int) *List {
 	glist := C.g_list_insert(v.native(), C.gpointer(data), C.gint(position))
-	return wrapList(glist)
+	return v.wrapNewHead(glist)
 }
 
 // Length is a wrapper around g_list_length().
@@ -59,8 +77,19 @@ func (v *List) Length() uint {
 }
 
 // NthData is a wrapper around g_list_nth_data().
-func (v *List) NthData(n uint) interface{} {
-	return C.g_list_nth_data(v.native(), C.guint(n))
+func (v *List) NthData(n uint) unsafe.Pointer {
+	return unsafe.Pointer(C.g_list_nth_data(v.native(), C.guint(n)))
+}
+
+// NthDataWrapped acts the same as NthData(), but passes
+// retrieved value before returning through wrap function, set by DataWrapper().
+// If no wrap function is set, it returns raw unsafe.Pointer.
+func (v *List) NthDataWrapped(n uint) interface{} {
+	ptr := v.NthData(n)
+	if v.dataWrap != nil {
+		return v.dataWrap(ptr)
+	}
+	return ptr
 }
 
 // Free is a wrapper around g_list_free().
@@ -70,15 +99,26 @@ func (v *List) Free() {
 
 // Next is a wrapper around the next struct field
 func (v *List) Next() *List {
-	return wrapList(v.native().next)
+	return v.wrapNewHead(v.native().next)
 }
 
 // Previous is a wrapper around the prev struct field
 func (v *List) Previous() *List {
-	return wrapList(v.native().prev)
+	return v.wrapNewHead(v.native().prev)
 }
 
 // Data is a wrapper around the data struct field
 func (v *List) Data() unsafe.Pointer {
 	return unsafe.Pointer(v.native().data)
+}
+
+// DataWrapped acts the same as Data(), but passes
+// retrieved value before returning through wrap function, set by DataWrapper().
+// If no wrap function is set, it returns raw unsafe.Pointer.
+func (v *List) DataWrapped() interface{} {
+	ptr := v.Data()
+	if v.dataWrap != nil {
+		return v.dataWrap(ptr)
+	}
+	return ptr
 }

--- a/glib/list.go
+++ b/glib/list.go
@@ -56,6 +56,9 @@ func (v *List) native() *C.struct__GList {
 // and DataWrapped(). It's used to cast raw C data into appropriate
 // Go structures and types every time that data is retreived.
 func (v *List) DataWrapper(fn func(unsafe.Pointer) interface{}) {
+	if v == nil {
+		return
+	}
 	v.dataWrap = fn
 }
 

--- a/glib/list.go
+++ b/glib/list.go
@@ -79,6 +79,6 @@ func (v *List) Previous() *List {
 }
 
 // Data is a wrapper around the data struct field
-func (v *List) Data() uintptr {
-	return uintptr(v.native().data)
+func (v *List) Data() unsafe.Pointer {
+	return unsafe.Pointer(v.native().data)
 }

--- a/glib/list.go
+++ b/glib/list.go
@@ -25,10 +25,16 @@ func WrapList(obj uintptr) *List {
 }
 
 func wrapList(obj *C.struct__GList) *List {
+	if obj == nil {
+		return nil
+	}
 	return &List{list: obj}
 }
 
 func (v *List) wrapNewHead(obj *C.struct__GList) *List {
+	if obj == nil {
+		return nil
+	}
 	return &List{
 		list:     obj,
 		dataWrap: v.dataWrap,

--- a/glib/list_test.go
+++ b/glib/list_test.go
@@ -1,0 +1,42 @@
+package glib
+
+import (
+	"fmt"
+	"testing"
+	"unsafe"
+)
+
+func TestList_Basics(t *testing.T) {
+	list := (&List{}).Append(0).Append(1).Append(2)
+	if list.Length() != 3 {
+		t.Errorf("Length of list with 3 appended elements must be 3. (Got %v).", list.Length())
+	}
+
+	list = (&List{}).Prepend(0).Prepend(1).Prepend(2)
+	if list.Length() != 3 {
+		t.Errorf("Length of list with 3 prepended elements must be 3. (Got %v).", list.Length())
+	}
+
+	list = (&List{}).Insert(0, 0).Insert(1, 0).Insert(2, 0)
+	if list.Length() != 3 {
+		t.Errorf("Length of list with 3 inserted elements must be 3. (Got %v).", list.Length())
+	}
+}
+
+func TestList_DataWrapper(t *testing.T) {
+	list := (&List{}).Append(0).Append(1).Append(2)
+	list.DataWrapper(func(ptr unsafe.Pointer) interface{} {
+		return fmt.Sprintf("Value %v", uintptr(ptr))
+	})
+
+	for l := list; l.list != nil; l = l.Next() {
+		expect := fmt.Sprintf("Value %v", uintptr(l.Data()))
+		actual, ok := l.DataWrapped().(string)
+		if !ok {
+			t.Error("DataWrapper must have returned a string!")
+		}
+		if actual != expect {
+			t.Errorf("DataWrapper returned unexpected result. Expected '%v', got '%v'.", expect, actual)
+		}
+	}
+}

--- a/glib/list_test.go
+++ b/glib/list_test.go
@@ -29,7 +29,7 @@ func TestList_DataWrapper(t *testing.T) {
 		return fmt.Sprintf("Value %v", uintptr(ptr))
 	})
 
-	for l := list; l.list != nil; l = l.Next() {
+	for l := list; l != nil; l = l.Next() {
 		expect := fmt.Sprintf("Value %v", uintptr(l.Data()))
 		actual, ok := l.DataWrapped().(string)
 		if !ok {

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -2861,8 +2861,8 @@ func (v *Container) GetFocusChain() ([]*Widget, bool) {
 
 	var widgets []*Widget
 	wlist := glib.WrapList(uintptr(unsafe.Pointer(cwlist)))
-	for ; wlist.Data() != uintptr(unsafe.Pointer(nil)); wlist = wlist.Next() {
-		widgets = append(widgets, wrapWidget(wrapObject(unsafe.Pointer(wlist.Data()))))
+	for ; wlist.Data() != nil; wlist = wlist.Next() {
+		widgets = append(widgets, wrapWidget(wrapObject(wlist.Data())))
 	}
 	return widgets, gobool(c)
 }
@@ -8916,7 +8916,7 @@ func TreePathFromList(list *glib.List) *TreePath {
 	if list == nil {
 		return nil
 	}
-	return &TreePath{(*C.GtkTreePath)(unsafe.Pointer(list.Data()))}
+	return &TreePath{(*C.GtkTreePath)(list.Data())}
 }
 
 // native returns a pointer to the underlying GtkTreePath.


### PR DESCRIPTION
Trying to simplify interface for retrieving glib.List elements when gtk returns one. Added `dataWrap` function field to glib.List and methods `NthDataWrapped` and `DataWrapped`, which call that function to wrap raw data into Go types.

The wrapper has to be specified during List initialization...
```
	glist.DataWrapper(func(ptr unsafe.Pointer) interface{} {
		return &TreePath{(*C.GtkTreePath)(ptr)}
	})
```
...to ease getting List's data into this
```
	path := l.NthDataWrapped(i).(*gtk.TreePath)
```

I thought about more universal way of casting raw Gtk+ data into Go types. E.g. there's a large `WrapMap`, defined in gtk.go. But some GTK+ values are not GObjects (GtkTreePath is not), therefore their type cannot be determined during runtime for automatic casting.

**Todo:** may be, remove NthData() and Data() completely and replace with *Wrapped versions? Or at least make them unexported?