### PR TITLE
Correct type in GetSelectedRows finalizer.

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -8296,7 +8296,7 @@ func (v *TreeSelection) GetSelectedRows(model ITreeModel) *glib.List {
 	})
 	runtime.SetFinalizer(glist, func(glist *glib.List) {
 		glist.FreeFull(func(item interface{}) {
-			path := item.(TreePath)
+			path := item.(*TreePath)
 			C.gtk_tree_path_free(path.GtkTreePath)
 		})
 	})


### PR DESCRIPTION
I hit this panic.

```
panic: interface conversion: interface is *gtk.TreePath, not gtk.TreePath

goroutine 4 [running]:
panic(0xbb93a0, 0xc820368040)
	/usr/local/go/src/runtime/panic.go:464 +0x3e6
github.com/pekim/mixlac-go/vendor/github.com/gotk3/gotk3/gtk.(*TreeSelection).GetSelectedRows.func2.1(0xbe26c0, 0xc82013a018)
	/home/mike/go/src/github.com/pekim/mixlac-go/vendor/github.com/gotk3/gotk3/gtk/gtk.go:8299 +0x4c
github.com/pekim/mixlac-go/vendor/github.com/gotk3/gotk3/glib.(*List).Foreach(0xc8203eedd0, 0xeb9f30)
	/home/mike/go/src/github.com/pekim/mixlac-go/vendor/github.com/gotk3/gotk3/glib/list.go:146 +0x58
github.com/pekim/mixlac-go/vendor/github.com/gotk3/gotk3/glib.(*List).FreeFull(0xc8203eedd0, 0xeb9f30)
	/home/mike/go/src/github.com/pekim/mixlac-go/vendor/github.com/gotk3/gotk3/glib/list.go:154 +0x2b
github.com/pekim/mixlac-go/vendor/github.com/gotk3/gotk3/gtk.(*TreeSelection).GetSelectedRows.func2(0xc8203eedd0)
	/home/mike/go/src/github.com/pekim/mixlac-go/vendor/github.com/gotk3/gotk3/gtk/gtk.go:8301 +0x2d
```

I've not had this happen again since I made this small fix.