### PR TITLE
Add GtkColorButton to WrapMap

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -8570,6 +8570,7 @@ var WrapMap = map[string]WrapFn{
 	"GtkCheckButton":         wrapCheckButton,
 	"GtkCheckMenuItem":       wrapCheckMenuItem,
 	"GtkClipboard":           wrapClipboard,
+	"GtkColorButton":         wrapColorButton,
 	"GtkContainer":           wrapContainer,
 	"GtkDialog":              wrapDialog,
 	"GtkDrawingArea":         wrapDrawingArea,


### PR DESCRIPTION
For some reason (it was forgotten?) GtkColorButton did not have its wrapping function in WrapMap. This PR should fix issue #113. As far as I could see, all other wrapping functions were already in WrapMap.