### PR TITLE
Add a function to create *EventKey from a *Event.

### DIFF
--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -985,6 +985,19 @@ func EventKeyNew() *EventKey {
 	return &EventKey{&ev}
 }
 
+// EventKeyNewFromEvent returns an EventKey from an Event.
+//
+// Using widget.Connect() for a key related signal such as
+// "key-press-event" results in a *Event being passed as
+// the callback's second argument. The argument is actually a
+// *EventKey. EventKeyNewFromEvent provides a means of creating
+// an EventKey from the Event.
+func EventKeyNewFromEvent(event *Event) *EventKey {
+	ee := (*C.GdkEvent)(unsafe.Pointer(event.native()))
+	ev := Event{ee}
+	return &EventKey{&ev}
+}
+
 // Native returns a pointer to the underlying GdkEventKey.
 func (v *EventKey) Native() uintptr {
 	return uintptr(unsafe.Pointer(v.native()))


### PR DESCRIPTION
This is for when a *Event represents a GdkEventKey.

Like I say in the doc for `EventKeyNewFromEvent`, this facilitates something like this.

```go
	window.Connect("key-press-event", func(_ *gtk.Window, event *gdk.Event) {
		eventKey := gdk.EventKeyNewFromEvent(event)
		fmt.Println(eventKey.KeyVal(), eventKey.State())
	})
```

Perhaps there's a way of achieving this without creating a function like this?