### PR TITLE
Add event propagation constants.

### DIFF
--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -290,6 +290,13 @@ const (
 	DEVICE_TYPE_FLOATING DeviceType = C.GDK_DEVICE_TYPE_FLOATING
 )
 
+// EventPropagation constants
+
+const (
+	GDK_EVENT_PROPAGATE bool = C.GDK_EVENT_PROPAGATE != 0
+	GDK_EVENT_STOP      bool = C.GDK_EVENT_STOP != 0
+)
+
 /*
  * GdkAtom
  */


### PR DESCRIPTION
For use when returning from an event handler where control of event propagation is required.

Example usage.
```go
    window.Connect("key-press-event", func(_ *gtk.Window, event *gdk.Event) bool {
        eventKey := gdk.EventKeyNewFromEvent(event)
        if eventKey.KeyVal() == ... {
                // handle the event in some way
                return gdk.GDK_EVENT_STOP
        }
        return gdk.GDK_EVENT_PROPAGATE
    })
```