### PR TITLE
Add support for gtk_gird_remove_row/column and gtk_container_child_get_property

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -2488,6 +2488,19 @@ func (v *Container) ChildNotify(child IWidget, childProperty string) {
 		(*C.gchar)(cstr))
 }
 
+// ChildGetProperty is a wrapper around gtk_container_child_get_property().
+func (v *Container) ChildGetProperty(child IWidget, name string, valueType glib.Type) (interface{}, error) {
+	gv, e := glib.ValueInit(valueType)
+	if e != nil {
+		return nil, e
+	}
+	cstr := C.CString(name)
+	defer C.free(unsafe.Pointer(cstr))
+
+	C.gtk_container_child_get_property(v.native(), child.toWidget(), (*C.gchar)(cstr), (*C.GValue)(unsafe.Pointer(gv.Native())))
+	return gv.GoValue()
+}
+
 // ChildSetProperty is a wrapper around gtk_container_child_set_property().
 func (v *Container) ChildSetProperty(child IWidget, name string, value interface{}) error {
 	gv, e := glib.GValue(value)

--- a/gtk/gtk_since_3_10.go
+++ b/gtk/gtk_since_3_10.go
@@ -109,6 +109,19 @@ func ButtonNewFromIconName(iconName string, size IconSize) (*Button, error) {
 }
 
 /*
+ * GtkGrid
+ */
+// RemoveRow() is a wrapper around gtk_grid_remove_row().
+func (v *Grid) RemoveRow(position int) {
+	C.gtk_grid_remove_row(v.native(), C.gint(position))
+}
+
+// RemoveColumn() is a wrapper around gtk_grid_remove_column().
+func (v *Grid) RemoveColumn(position int) {
+	C.gtk_grid_remove_column(v.native(), C.gint(position))
+}
+
+/*
  * GtkHeaderBar
  */
 


### PR DESCRIPTION
Added support for [`gtk_grid_remove_row`](https://developer.gnome.org/gtk3/stable/GtkGrid.html#gtk-grid-remove-row) and [`gtk_grid_remove_column`](https://developer.gnome.org/gtk3/stable/GtkGrid.html#gtk-grid-remove-column) methods, which are added to gtk3 since 3.10.