### PR TITLE
Add support for gdk: unicode_to_keyval and keyval_to_unicode

### DIFF
--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -834,6 +834,14 @@ func KeyvalToUpper(v uint) uint {
 	return uint(C.gdk_keyval_to_upper(C.guint(v)))
 }
 
+func KeyvalToUnicode(v uint) rune {
+	return rune(C.gdk_keyval_to_unicode(C.guint(v)))
+}
+
+func UnicodeToKeyval(v rune) uint {
+	return uint(C.gdk_unicode_to_keyval(C.guint32(v)))
+}
+
 /*
  * GdkDragContext
  */


### PR DESCRIPTION
Added wrapper functions for [`gdk_unicode_to_keyval`](https://developer.gnome.org/gdk3/stable/gdk3-Keyboard-Handling.html#gdk-unicode-to-keyval) and [`gdk_keyval_to_unicode`](https://developer.gnome.org/gdk3/stable/gdk3-Keyboard-Handling.html#gdk-keyval-to-unicode).
These functions can be used in `key-press-event` signal to determine whether the pressed key is a printable character (`gdk_keyval_to_unicode(keyval) != 0`)