### PR TITLE
Fix ISC LICENSE, change 'and' to 'and/or', to avoid confusion

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Copyright (c) 2013-2014 Conformal Systems LLC.
 
-Permission to use, copy, modify, and distribute this software for any
+Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above
 copyright notice and this permission notice appear in all copies.
 


### PR DESCRIPTION
Fix ISC LICENSE, change 'and' to 'and/or', to avoid confusion
Read: https://en.wikipedia.org/wiki/ISC_license

I also think you change change `2013-2014` to `2013-2016`