### PR TITLE
Fixed documentation error.

### DIFF
--- a/gtk/gtk_since_3_10.go
+++ b/gtk/gtk_since_3_10.go
@@ -111,6 +111,7 @@ func ButtonNewFromIconName(iconName string, size IconSize) (*Button, error) {
 /*
  * GtkGrid
  */
+
 // RemoveRow() is a wrapper around gtk_grid_remove_row().
 func (v *Grid) RemoveRow(position int) {
 	C.gtk_grid_remove_row(v.native(), C.gint(position))


### PR DESCRIPTION
Added a newline between the two comments so `* GtkGrid` does not show up in the documentation.

before: https://godoc.org/github.com/gotk3/gotk3/gtk#Grid.RemoveRow
after: https://godoc.org/github.com/reujab/gotk3/gtk#Grid.RemoveRow