### PR TITLE
Do not call set_string on NULL pointer in g_application_run wrapper

### DIFF
--- a/glib/application.go
+++ b/glib/application.go
@@ -194,8 +194,6 @@ func (v *Application) Run(args []string) int {
 		C.set_string(cargs, C.int(i), (*C.char)(cstr))
 	}
 
-	C.set_string(cargs, C.int(len(args)), nil)
-
 	return int(C.g_application_run(v.native(), C.int(len(args)), cargs))
 }
 


### PR DESCRIPTION
This leads to a segfault. And seems to have no meaning.