### PR TITLE
added wrapper around gtk_scale_set_draw_value

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -6511,6 +6511,11 @@ func ScaleNewWithRange(orientation Orientation, min, max, step float64) (*Scale,
 	return wrapScale(wrapObject(unsafe.Pointer(c))), nil
 }
 
+// SetDrawValue() is a wrapper around gtk_scale_set_draw_value().
+func (v *Scale) SetDrawValue(drawValue bool) {
+    C.gtk_scale_set_draw_value(v.native(), gbool(drawValue))
+}
+
 /*
  * GtkScaleButton
  */


### PR DESCRIPTION
Hi,
I'm working on a toy project that needs the wrapper to gtk_scale_set_draw_value(); since I didn't find it, I just added it; hopefully it can be merged if anybody else needs it.

Thanks,
Andrea
