### PR TITLE
Unreferring address that still in use is causing trouble 

### DIFF
--- a/gtk/gtk_export.go
+++ b/gtk/gtk_export.go
@@ -19,8 +19,8 @@ func substring_match_equal_func(model *C.GtkTreeModel,
 	iter *C.GtkTreeIter,
 	data C.gpointer) C.gboolean {
 
-	goModel := &TreeModel{glib.Take(unsafe.Pointer(model))}
-	defer goModel.Unref()
+	gobj := glib.Object{glib.ToGObject(unsafe.Pointer(model))}
+	goModel := &TreeModel{&gobj}
 	goIter := &TreeIter{(C.GtkTreeIter)(*iter)}
 
 	value, err := goModel.GetValue(goIter, int(column))

--- a/gtk/gtk_export.go
+++ b/gtk/gtk_export.go
@@ -19,8 +19,7 @@ func substring_match_equal_func(model *C.GtkTreeModel,
 	iter *C.GtkTreeIter,
 	data C.gpointer) C.gboolean {
 
-	gobj := glib.Object{glib.ToGObject(unsafe.Pointer(model))}
-	goModel := &TreeModel{&gobj}
+	goModel := &TreeModel{glib.Take(unsafe.Pointer(model))}
 	goIter := &TreeIter{(C.GtkTreeIter)(*iter)}
 
 	value, err := goModel.GetValue(goIter, int(column))


### PR DESCRIPTION
The address of `model *C.GtkTreeModel` that I received as parameter still in use in other places so unreferring it is causing trouble.
