### PR TITLE
Add support for SetMode(),GetMode() on ToggleButton

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -7678,6 +7678,17 @@ func (v *ToggleButton) SetActive(isActive bool) {
 	C.gtk_toggle_button_set_active(v.native(), gbool(isActive))
 }
 
+// GetMode is a wrapper around gtk_toggle_button_get_mode().
+func (v *ToggleButton) GetMode() bool {
+	c := C.gtk_toggle_button_get_mode(v.native())
+	return gobool(c)
+}
+
+// SetMode is a wrapper around gtk_toggle_button_set_mode().
+func (v *ToggleButton) SetMode(drawIndicator bool) {
+	C.gtk_toggle_button_set_mode(v.native(), gbool(drawIndicator))
+}
+
 /*
  * GtkToolbar
  */


### PR DESCRIPTION
Add support for `SetMode()`,`GetMode()` on `ToggleButton` for `CheckButton`, `RadioButton` to disable `drawIndicator` property with. This lets a group of `RadioButtons` appear like a `StackSwitcher` by reverting their display back to the pressed/depressed button.

This relates to #228 