### PR TITLE
Implement GAction and related types

### DIFF
--- a/glib/application.go
+++ b/glib/application.go
@@ -11,6 +11,9 @@ import "unsafe"
 // Application is a representation of GApplication.
 type Application struct {
 	*Object
+
+	// Interfaces
+	ActionMap
 }
 
 // native() returns a pointer to the underlying GApplication.
@@ -31,7 +34,8 @@ func marshalApplication(p uintptr) (interface{}, error) {
 }
 
 func wrapApplication(obj *Object) *Application {
-	return &Application{obj}
+	am := wrapActionMap(obj)
+	return &Application{obj, *am}
 }
 
 // ApplicationIDIsValid is a wrapper around g_application_id_is_valid().

--- a/glib/application.go
+++ b/glib/application.go
@@ -14,6 +14,7 @@ type Application struct {
 
 	// Interfaces
 	ActionMap
+	ActionGroup
 }
 
 // native() returns a pointer to the underlying GApplication.
@@ -35,7 +36,8 @@ func marshalApplication(p uintptr) (interface{}, error) {
 
 func wrapApplication(obj *Object) *Application {
 	am := wrapActionMap(obj)
-	return &Application{obj, *am}
+	ag := wrapActionGroup(obj)
+	return &Application{obj, *am, *ag}
 }
 
 // ApplicationIDIsValid is a wrapper around g_application_id_is_valid().

--- a/glib/gaction.go
+++ b/glib/gaction.go
@@ -1,0 +1,215 @@
+package glib
+
+// #cgo pkg-config: glib-2.0 gobject-2.0
+// #include <gio/gio.h>
+// #include <glib.h>
+// #include <glib-object.h>
+// #include "glib.go.h"
+import "C"
+import "unsafe"
+
+// Action is a representation of glib's GAction GInterface.
+type Action struct {
+	*Object
+}
+
+// IAction is an interface type implemented by all structs
+// embedding an Action.  It is meant to be used as an argument type
+// for wrapper functions that wrap around a C function taking a
+// GAction.
+type IAction interface {
+	toGAction() *C.GAction
+	toAction() *Action
+}
+
+func (v *Action) toGAction() *C.GAction {
+	if v == nil {
+		return nil
+	}
+	return v.native()
+}
+
+func (v *Action) toAction() *Action {
+	return v
+}
+
+// gboolean g_action_parse_detailed_name (const gchar *detailed_name, gchar **action_name, GVariant **target_value, GError **error);
+// gchar * g_action_print_detailed_name (const gchar *action_name, GVariant *target_value);
+
+// native() returns a pointer to the underlying GAction.
+func (v *Action) native() *C.GAction {
+	if v == nil || v.GObject == nil {
+		return nil
+	}
+	return C.toGAction(unsafe.Pointer(v.GObject))
+}
+
+func (v *Action) Native() uintptr {
+	return uintptr(unsafe.Pointer(v.native()))
+}
+
+func marshalAction(p uintptr) (interface{}, error) {
+	c := C.g_value_get_object((*C.GValue)(unsafe.Pointer(p)))
+	return wrapAction(wrapObject(unsafe.Pointer(c))), nil
+}
+
+func wrapAction(obj *Object) *Action {
+	return &Action{obj}
+}
+
+// ActionNameIsValid is a wrapper around g_action_name_is_valid
+func ActionNameIsValid(actionName string) bool {
+	cstr := (*C.gchar)(C.CString(actionName))
+	return gobool(C.g_action_name_is_valid(cstr))
+}
+
+// GetName is a wrapper around g_action_get_name
+func (v *Action) GetName() string {
+	return C.GoString((*C.char)(C.g_action_get_name(v.native())))
+}
+
+// GetEnabled is a wrapper around g_action_get_enabled
+func (v *Action) GetEnabled() bool {
+	return gobool(C.g_action_get_enabled(v.native()))
+}
+
+// GetState is a wrapper around g_action_get_state
+func (v *Action) GetState() *Variant {
+	c := C.g_action_get_state(v.native())
+	if c == nil {
+		return nil
+	}
+	return newVariant((*C.GVariant)(c))
+}
+
+// GetStateHint is a wrapper around g_action_get_state_hint
+func (v *Action) GetStateHint() *Variant {
+	c := C.g_action_get_state_hint(v.native())
+	if c == nil {
+		return nil
+	}
+	return newVariant((*C.GVariant)(c))
+}
+
+// GetParameterType is a wrapper around g_action_get_parameter_type
+func (v *Action) GetParameterType() *VariantType {
+	c := C.g_action_get_parameter_type(v.native())
+	if c == nil {
+		return nil
+	}
+	return newVariantType((*C.GVariantType)(c))
+}
+
+// GetStateType is a wrapper around g_action_get_state_type
+func (v *Action) GetStateType() *VariantType {
+	c := C.g_action_get_state_type(v.native())
+	if c == nil {
+		return nil
+	}
+	return newVariantType((*C.GVariantType)(c))
+}
+
+// ChangeState is a wrapper around g_action_change_state
+func (v *Action) ChangeState(value *Variant) {
+	C.g_action_change_state(v.native(), value.native())
+}
+
+// Activate is a wrapper around g_action_activate
+func (v *Action) Activate(parameter *Variant) {
+	C.g_action_activate(v.native(), parameter.native())
+}
+
+// SimpleAction is a representation of GSimpleAction
+type SimpleAction struct {
+	Action
+}
+
+func (v *SimpleAction) native() *C.GSimpleAction {
+	if v == nil || v.GObject == nil {
+		return nil
+	}
+	return C.toGSimpleAction(unsafe.Pointer(v.GObject))
+}
+
+func (v *SimpleAction) Native() uintptr {
+	return uintptr(unsafe.Pointer(v.native()))
+}
+
+func marshalSimpleAction(p uintptr) (interface{}, error) {
+	c := C.g_value_get_object((*C.GValue)(unsafe.Pointer(p)))
+	return wrapSimpleAction(wrapObject(unsafe.Pointer(c))), nil
+}
+
+func wrapSimpleAction(obj *Object) *SimpleAction {
+	return &SimpleAction{Action{obj}}
+}
+
+// SimpleActionNew is a wrapper around g_simple_action_new
+func SimpleActionNew(name string, parameterType *VariantType) *SimpleAction {
+	c := C.g_simple_action_new((*C.gchar)(C.CString(name)), parameterType.native())
+	if c == nil {
+		return nil
+	}
+	return wrapSimpleAction(wrapObject(unsafe.Pointer(c)))
+}
+
+// SimpleActionNewStateful is a wrapper around g_simple_action_new_stateful
+func SimpleActionNewStateful(name string, parameterType *VariantType, state *Variant) *SimpleAction {
+	c := C.g_simple_action_new_stateful((*C.gchar)(C.CString(name)), parameterType.native(), state.native())
+	if c == nil {
+		return nil
+	}
+	return wrapSimpleAction(wrapObject(unsafe.Pointer(c)))
+}
+
+// SetEnabled is a wrapper around g_simple_action_set_enabled
+func (v *SimpleAction) SetEnabled(enabled bool) {
+	C.g_simple_action_set_enabled(v.native(), gbool(enabled))
+}
+
+// SetState is a wrapper around g_simple_action_set_state
+// This should only be called by the implementor of the action.
+// Users of the action should not attempt to directly modify the 'state' property.
+// Instead, they should call ChangeState [g_action_change_state()] to request the change.
+func (v *SimpleAction) SetState(value *Variant) {
+	C.g_simple_action_set_state(v.native(), value.native())
+}
+
+// SetStateHint is a wrapper around g_simple_action_set_state_hint
+func (v *SimpleAction) SetStateHint(stateHint *Variant) {
+	C.g_simple_action_set_state_hint(v.native(), stateHint.native())
+}
+
+// PropertyAction is a representation of GPropertyAction
+type PropertyAction struct {
+	Action
+}
+
+func (v *PropertyAction) native() *C.GPropertyAction {
+	if v == nil || v.GObject == nil {
+		return nil
+	}
+	return C.toGPropertyAction(unsafe.Pointer(v.GObject))
+}
+
+func (v *PropertyAction) Native() uintptr {
+	return uintptr(unsafe.Pointer(v.native()))
+}
+
+func marshalPropertyAction(p uintptr) (interface{}, error) {
+	c := C.g_value_get_object((*C.GValue)(unsafe.Pointer(p)))
+	return wrapPropertyAction(wrapObject(unsafe.Pointer(c))), nil
+}
+
+func wrapPropertyAction(obj *Object) *PropertyAction {
+	return &PropertyAction{Action{obj}}
+}
+
+// PropertyActionNew is a wrapper around g_property_action_new
+func PropertyActionNew(name string, object *Object, propertyName string) *PropertyAction {
+	c := C.g_property_action_new((*C.gchar)(C.CString(name)), C.gpointer(unsafe.Pointer(object.native())), (*C.gchar)(C.CString(propertyName)))
+	if c == nil {
+		return nil
+	}
+	return wrapPropertyAction(wrapObject(unsafe.Pointer(c)))
+}

--- a/glib/gaction.go
+++ b/glib/gaction.go
@@ -176,9 +176,10 @@ func (v *SimpleAction) SetState(value *Variant) {
 }
 
 // SetStateHint is a wrapper around g_simple_action_set_state_hint
-func (v *SimpleAction) SetStateHint(stateHint *Variant) {
+// GLib 2.44 only (currently no build tags, so commented out)
+/*func (v *SimpleAction) SetStateHint(stateHint *Variant) {
 	C.g_simple_action_set_state_hint(v.native(), stateHint.native())
-}
+}*/
 
 // PropertyAction is a representation of GPropertyAction
 type PropertyAction struct {

--- a/glib/gactiongroup.go
+++ b/glib/gactiongroup.go
@@ -1,0 +1,99 @@
+package glib
+
+// #cgo pkg-config: glib-2.0 gobject-2.0
+// #include <gio/gio.h>
+// #include <glib.h>
+// #include <glib-object.h>
+// #include "glib.go.h"
+import "C"
+import "unsafe"
+
+// ActionGroup is a representation of glib's GActionGroup GInterface
+type ActionGroup struct {
+	*Object
+}
+
+// g_action_group_list_actions()
+// g_action_group_query_action()
+// should only called from implementations:
+// g_action_group_action_added
+// g_action_group_action_removed
+// g_action_group_action_enabled_changed
+// g_action_group_action_state_changed
+
+// native() returns a pointer to the underlying GActionGroup.
+func (v *ActionGroup) native() *C.GActionGroup {
+	if v == nil || v.GObject == nil {
+		return nil
+	}
+	return C.toGActionGroup(unsafe.Pointer(v.GObject))
+}
+
+func (v *ActionGroup) Native() uintptr {
+	return uintptr(unsafe.Pointer(v.native()))
+}
+
+func marshalActionGroup(p uintptr) (interface{}, error) {
+	c := C.g_value_get_object((*C.GValue)(unsafe.Pointer(p)))
+	return wrapActionGroup(wrapObject(unsafe.Pointer(c))), nil
+}
+
+func wrapActionGroup(obj *Object) *ActionGroup {
+	return &ActionGroup{obj}
+}
+
+// HasAction is a wrapper around g_action_group_has_action().
+func (v *ActionGroup) HasAction(actionName string) bool {
+	return gobool(C.g_action_group_has_action(v.native(), (*C.gchar)(C.CString(actionName))))
+}
+
+// GetActionEnabled is a wrapper around g_action_group_get_action_enabled().
+func (v *ActionGroup) GetActionEnabled(actionName string) bool {
+	return gobool(C.g_action_group_get_action_enabled(v.native(), (*C.gchar)(C.CString(actionName))))
+}
+
+// GetActionParameterType is a wrapper around g_action_group_get_action_parameter_type().
+func (v *ActionGroup) GetActionParameterType(actionName string) *VariantType {
+	c := C.g_action_group_get_action_parameter_type(v.native(), (*C.gchar)(C.CString(actionName)))
+	if c == nil {
+		return nil
+	}
+	return newVariantType((*C.GVariantType)(c))
+}
+
+// GetActionStateType is a wrapper around g_action_group_get_action_state_type().
+func (v *ActionGroup) GetActionStateType(actionName string) *VariantType {
+	c := C.g_action_group_get_action_state_type(v.native(), (*C.gchar)(C.CString(actionName)))
+	if c == nil {
+		return nil
+	}
+	return newVariantType((*C.GVariantType)(c))
+}
+
+// GetActionState is a wrapper around g_action_group_get_action_state().
+func (v *ActionGroup) GetActionState(actionName string) *Variant {
+	c := C.g_action_group_get_action_state(v.native(), (*C.gchar)(C.CString(actionName)))
+	if c == nil {
+		return nil
+	}
+	return newVariant((*C.GVariant)(c))
+}
+
+// GetActionStateHint is a wrapper around g_action_group_get_action_state_hint().
+func (v *ActionGroup) GetActionStateHint(actionName string) *Variant {
+	c := C.g_action_group_get_action_state_hint(v.native(), (*C.gchar)(C.CString(actionName)))
+	if c == nil {
+		return nil
+	}
+	return newVariant((*C.GVariant)(c))
+}
+
+// ChangeActionState is a wrapper around g_action_group_change_action_state
+func (v *ActionGroup) ChangeActionState(actionName string, value *Variant) {
+	C.g_action_group_change_action_state(v.native(), (*C.gchar)(C.CString(actionName)), value.native())
+}
+
+// Activate is a wrapper around g_action_group_activate_action
+func (v *ActionGroup) Activate(actionName string, parameter *Variant) {
+	C.g_action_group_activate_action(v.native(), (*C.gchar)(C.CString(actionName)), parameter.native())
+}

--- a/glib/gactionmap.go
+++ b/glib/gactionmap.go
@@ -1,0 +1,57 @@
+package glib
+
+// #cgo pkg-config: glib-2.0 gobject-2.0
+// #include <gio/gio.h>
+// #include <glib.h>
+// #include <glib-object.h>
+// #include "glib.go.h"
+import "C"
+import "unsafe"
+
+// ActionMap is a representation of glib's GActionMap GInterface
+type ActionMap struct {
+	*Object
+}
+
+// void g_action_map_add_action_entries (GActionMap *action_map, const GActionEntry *entries, gint n_entries, gpointer user_data);
+// struct GActionEntry
+
+// native() returns a pointer to the underlying GActionMap.
+func (v *ActionMap) native() *C.GActionMap {
+	if v == nil || v.GObject == nil {
+		return nil
+	}
+	return C.toGActionMap(unsafe.Pointer(v.GObject))
+}
+
+func (v *ActionMap) Native() uintptr {
+	return uintptr(unsafe.Pointer(v.native()))
+}
+
+func marshalActionMap(p uintptr) (interface{}, error) {
+	c := C.g_value_get_object((*C.GValue)(unsafe.Pointer(p)))
+	return wrapActionMap(wrapObject(unsafe.Pointer(c))), nil
+}
+
+func wrapActionMap(obj *Object) *ActionMap {
+	return &ActionMap{obj}
+}
+
+// LookupAction is a wrapper around g_action_map_lookup_action
+func (v *ActionMap) LookupAction(actionName string) *Action {
+	c := C.g_action_map_lookup_action(v.native(), (*C.gchar)(C.CString(actionName)))
+	if c == nil {
+		return nil
+	}
+	return wrapAction(wrapObject(unsafe.Pointer(c)))
+}
+
+// AddAction is a wrapper around g_action_map_add_action
+func (v *ActionMap) AddAction(action IAction) {
+	C.g_action_map_add_action(v.native(), action.toGAction())
+}
+
+// RemoveAction is a wrapper around g_action_map_remove_action
+func (v *ActionMap) RemoveAction(actionName string) {
+	C.g_action_map_remove_action(v.native(), (*C.gchar)(C.CString(actionName)))
+}

--- a/glib/glib.go.h
+++ b/glib/glib.go.h
@@ -38,6 +38,30 @@ toGObject(void *p)
 	return (G_OBJECT(p));
 }
 
+static GAction *
+toGAction(void *p)
+{
+	return (G_ACTION(p));
+}
+
+static GActionMap *
+toGActionMap(void *p)
+{
+	return (G_ACTION_MAP(p));
+}
+
+static GSimpleAction *
+toGSimpleAction(void *p)
+{
+	return (G_SIMPLE_ACTION(p));
+}
+
+static GPropertyAction *
+toGPropertyAction(void *p)
+{
+	return (G_PROPERTY_ACTION(p));
+}
+
 static GMenuModel *
 toGMenuModel(void *p)
 {

--- a/glib/glib.go.h
+++ b/glib/glib.go.h
@@ -44,6 +44,12 @@ toGAction(void *p)
 	return (G_ACTION(p));
 }
 
+static GActionGroup *
+toGActionGroup(void *p)
+{
+	return (G_ACTION_GROUP(p));
+}
+
 static GActionMap *
 toGActionMap(void *p)
 {
@@ -54,6 +60,12 @@ static GSimpleAction *
 toGSimpleAction(void *p)
 {
 	return (G_SIMPLE_ACTION(p));
+}
+
+static GSimpleActionGroup *
+toGSimpleActionGroup(void *p)
+{
+	return (G_SIMPLE_ACTION_GROUP(p));
 }
 
 static GPropertyAction *

--- a/glib/gsimpleactiongroup.go
+++ b/glib/gsimpleactiongroup.go
@@ -1,0 +1,59 @@
+package glib
+
+// #cgo pkg-config: glib-2.0 gobject-2.0
+// #include <gio/gio.h>
+// #include <glib.h>
+// #include <glib-object.h>
+// #include "glib.go.h"
+import "C"
+import (
+	"unsafe"
+)
+
+// SimpleActionGroup is a representation of glib's GSimpleActionGroup
+type SimpleActionGroup struct {
+	*Object
+
+	// Interfaces
+	ActionMap
+	ActionGroup
+}
+
+// deprecated since 2.38:
+// g_simple_action_group_lookup()
+// g_simple_action_group_insert()
+// g_simple_action_group_remove()
+// g_simple_action_group_add_entries()
+// -> See implementations in ActionMap
+
+// native() returns a pointer to the underlying GSimpleActionGroup.
+func (v *SimpleActionGroup) native() *C.GSimpleActionGroup {
+	if v == nil || v.GObject == nil {
+		return nil
+	}
+	return C.toGSimpleActionGroup(unsafe.Pointer(v.GObject))
+}
+
+func (v *SimpleActionGroup) Native() uintptr {
+	return uintptr(unsafe.Pointer(v.native()))
+}
+
+func marshalSimpleActionGroup(p uintptr) (interface{}, error) {
+	c := C.g_value_get_object((*C.GValue)(unsafe.Pointer(p)))
+	return wrapSimpleActionGroup(wrapObject(unsafe.Pointer(c))), nil
+}
+
+func wrapSimpleActionGroup(obj *Object) *SimpleActionGroup {
+	am := *wrapActionMap(obj)
+	ag := *wrapActionGroup(obj)
+	return &SimpleActionGroup{obj, am, ag}
+}
+
+// SimpleActionGroupNew is a wrapper around g_simple_action_group_new
+func SimpleActionGroupNew() *SimpleActionGroup {
+	c := C.g_simple_action_group_new()
+	if c == nil {
+		return nil
+	}
+	return wrapSimpleActionGroup(wrapObject(unsafe.Pointer(c)))
+}

--- a/glib/gvarianttype.go
+++ b/glib/gvarianttype.go
@@ -17,6 +17,9 @@ type VariantType struct {
 }
 
 func (v *VariantType) native() *C.GVariantType {
+	if v == nil {
+		return nil
+	}
 	return v.GVariantType
 }
 

--- a/gtk/application.go
+++ b/gtk/application.go
@@ -47,7 +47,8 @@ func marshalApplication(p uintptr) (interface{}, error) {
 }
 
 func wrapApplication(obj *glib.Object) *Application {
-	return &Application{glib.Application{obj}}
+	am := glib.ActionMap{obj}
+	return &Application{glib.Application{obj, am}}
 }
 
 // ApplicationNew is a wrapper around gtk_application_new().

--- a/gtk/application.go
+++ b/gtk/application.go
@@ -48,7 +48,8 @@ func marshalApplication(p uintptr) (interface{}, error) {
 
 func wrapApplication(obj *glib.Object) *Application {
 	am := glib.ActionMap{obj}
-	return &Application{glib.Application{obj, am}}
+	ag := glib.ActionGroup{obj}
+	return &Application{glib.Application{obj, am, ag}}
 }
 
 // ApplicationNew is a wrapper around gtk_application_new().

--- a/gtk/application_window.go
+++ b/gtk/application_window.go
@@ -19,6 +19,9 @@ import (
 // ApplicationWindow is a representation of GTK's GtkApplicationWindow.
 type ApplicationWindow struct {
 	Window
+
+	// Interfaces
+	glib.ActionMap
 }
 
 // native returns a pointer to the underlying GtkApplicationWindow.
@@ -37,7 +40,8 @@ func marshalApplicationWindow(p uintptr) (interface{}, error) {
 }
 
 func wrapApplicationWindow(obj *glib.Object) *ApplicationWindow {
-	return &ApplicationWindow{Window{Bin{Container{Widget{glib.InitiallyUnowned{obj}}}}}}
+	am := glib.ActionMap{obj}
+	return &ApplicationWindow{Window{Bin{Container{Widget{glib.InitiallyUnowned{obj}}}}}, am}
 }
 
 // ApplicationWindowNew is a wrapper around gtk_application_window_new().

--- a/gtk/application_window.go
+++ b/gtk/application_window.go
@@ -22,14 +22,15 @@ type ApplicationWindow struct {
 
 	// Interfaces
 	glib.ActionMap
+	glib.ActionGroup
 }
 
 // native returns a pointer to the underlying GtkApplicationWindow.
 func (v *ApplicationWindow) native() *C.GtkApplicationWindow {
-	if v == nil || v.GObject == nil {
+	if v == nil || v.Window.GObject == nil { // v.Window is necessary because v.GObject would be ambiguous
 		return nil
 	}
-	p := unsafe.Pointer(v.GObject)
+	p := unsafe.Pointer(v.Window.GObject)
 	return C.toGtkApplicationWindow(p)
 }
 
@@ -41,7 +42,8 @@ func marshalApplicationWindow(p uintptr) (interface{}, error) {
 
 func wrapApplicationWindow(obj *glib.Object) *ApplicationWindow {
 	am := glib.ActionMap{obj}
-	return &ApplicationWindow{Window{Bin{Container{Widget{glib.InitiallyUnowned{obj}}}}}, am}
+	ag := glib.ActionGroup{obj}
+	return &ApplicationWindow{Window{Bin{Container{Widget{glib.InitiallyUnowned{obj}}}}}, am, ag}
 }
 
 // ApplicationWindowNew is a wrapper around gtk_application_window_new().

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -5165,8 +5165,19 @@ func (v *MenuButton) GetPopup() *Menu {
 	return wrapMenu(glib.Take(unsafe.Pointer(c)))
 }
 
-// TODO: gtk_menu_button_set_menu_model
-// TODO: gtk_menu_button_get_menu_model
+// SetMenuModel is a wrapper around gtk_menu_button_set_menu_model().
+func (v *MenuButton) SetMenuModel(menuModel *glib.MenuModel) {
+	C.gtk_menu_button_set_menu_model(v.native(), C.toGMenuModel(unsafe.Pointer(menuModel.Native())))
+}
+
+// GetMenuModel is a wrapper around gtk_menu_button_get_menu_model().
+func (v *MenuButton) GetMenuModel() *glib.MenuModel {
+	c := C.gtk_menu_button_get_menu_model(v.native())
+	if c == nil {
+		return nil
+	}
+	return &glib.MenuModel{glib.Take(unsafe.Pointer(c))}
+}
 
 // SetDirection is a wrapper around gtk_menu_button_set_direction().
 func (v *MenuButton) SetDirection(direction ArrowType) {

--- a/gtk/gtk.go.h
+++ b/gtk/gtk.go.h
@@ -712,6 +712,12 @@ toGtkInfoBar(void *p)
 	return (GTK_INFO_BAR(p));
 }
 
+static GMenuModel *
+toGMenuModel(void *p)
+{
+	return (G_MENU_MODEL(p));
+}
+
 static GType *
 alloc_types(int n) {
 	return ((GType *)g_new0(GType, n));

--- a/gtk/gtk.go.h
+++ b/gtk/gtk.go.h
@@ -718,6 +718,12 @@ toGMenuModel(void *p)
 	return (G_MENU_MODEL(p));
 }
 
+static GActionGroup *
+toGActionGroup(void *p)
+{
+	return (G_ACTION_GROUP(p));
+}
+
 static GType *
 alloc_types(int n) {
 	return ((GType *)g_new0(GType, n));

--- a/gtk/widget.go
+++ b/gtk/widget.go
@@ -624,3 +624,7 @@ func (v *Widget) GetPreferredWidth() (int, int) {
 	C.gtk_widget_get_preferred_width(v.native(), &minimum, &natural)
 	return int(minimum), int(natural)
 }
+
+func (v *Widget) InsertActionGroup(name string, group *glib.ActionGroup) {
+	C.gtk_widget_insert_action_group(v.native(), (*C.gchar)(C.CString(name)), C.toGActionGroup(unsafe.Pointer(group.Native())))
+}


### PR DESCRIPTION
This PR implements types/functions related to actions. I got carried away when implementing the necessary pieces for GAction...
Including:
* glib.Action (interface)
* glib.SimpleAction
* glib.PropertyAction
* glib.ActionGroup (interface)
* glib.ActionMap (interface)
* glib.SimpleActionGroup
* gtk.Widget.InsertActionGroup
* implementations of the interfaces where possible

This PR builds upon my previous PR #230 as SetMenuModel is necessary for the example to work.

Next steps still open: Implement GActionable to allow actions on more or less any widget.

This is a working example:
As you can see, at some points ugly magic like `&customActionGroup.ActionGroup` is required to make everything work. If there are any suggestions to make this look better, don't hold back!

Is the repo gotk3/gotk3-examples still maintained? I have the example ready to be included there as well.

![image](https://user-images.githubusercontent.com/6136865/34625399-d71cbf4a-f258-11e7-83b6-bb6288f915b1.png)

``` go
package main

import (
	"log"
	"os"

	"github.com/gotk3/gotk3/glib"
	"github.com/gotk3/gotk3/gtk"
)

func main() {
	const appID = "com.github.gotk3.gotk3-examples"
	application, err := gtk.ApplicationNew(appID, glib.APPLICATION_FLAGS_NONE)
	if err != nil {
		log.Fatal("Could not create application:", err)
	}

	application.Connect("activate", func() {
		win := newWindow(application)

		aNew := glib.SimpleActionNew("new", nil)
		aNew.Connect("activate", func() {
			newWindow(application).ShowAll()
		})
		application.AddAction(aNew)

		aQuit := glib.SimpleActionNew("quit", nil)
		aQuit.Connect("activate", func() {
			application.Quit()
		})
		application.AddAction(aQuit)

		win.ShowAll()
	})

	os.Exit(application.Run(os.Args))
}

func newWindow(application *gtk.Application) *gtk.ApplicationWindow {
	win, err := gtk.ApplicationWindowNew(application)
	if err != nil {
		log.Fatal("Unable to create window:", err)
	}

	win.SetTitle("GOTK3 Actions Example")

	// Label text in the window
	lbl, err := gtk.LabelNew("Use the menu button to test the actions")
	if err != nil {
		log.Fatal("Could not create label:", err)
	}

	// Create a header bar
	header, err := gtk.HeaderBarNew()
	if err != nil {
		log.Fatal("Could not create header bar:", err)
	}
	header.SetShowCloseButton(true)
	header.SetTitle("GOTK3")
	header.SetSubtitle("Actions Example")

	// Create a new menu button
	mbtn, err := gtk.MenuButtonNew()
	if err != nil {
		log.Fatal("Could not create menu button:", err)
	}

	// Set up the menu model for the button
	menu := glib.MenuNew()
	if menu == nil {
		log.Fatal("Could not create menu (nil)")
	}
	// Actions with the prefix 'app' reference actions on the application
	// Actions with the prefix 'win' reference actions on the current window (specific to ApplicationWindow)
	// Other prefixes can be added to widgets via InsertActionGroup
	menu.Append("New Window", "app.new")
	menu.Append("Close Window", "win.close")
	menu.Append("Custom Panic", "custom.panic")
	menu.Append("Quit", "app.quit")

	// Create the action "win.close"
	aClose := glib.SimpleActionNew("close", nil)
	aClose.Connect("activate", func() {
		win.Close()
	})
	win.AddAction(aClose)

	// Create and insert custom action group with prefix "custom"
	customActionGroup := glib.SimpleActionGroupNew()
	win.InsertActionGroup("custom", &customActionGroup.ActionGroup)

	// Create an action in the custom action group
	aPanic := glib.SimpleActionNew("panic", nil)
	aPanic.Connect("activate", func() {
		lbl.SetLabel("PANIC!")
	})
	customActionGroup.AddAction(aPanic)
	win.AddAction(aPanic)

	mbtn.SetMenuModel(&menu.MenuModel)

	// add the menu button to the header
	header.PackStart(mbtn)

	// Assemble the window
	win.Add(lbl)
	win.SetTitlebar(header)
	win.SetPosition(gtk.WIN_POS_MOUSE)
	win.SetDefaultSize(600, 300)
	return win
}

```
