### PR TITLE
Implement InsertWithValues and add missing constants to make ListStore unsorted/sort by default column.

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -728,6 +728,13 @@ const (
 	SORT_DESCENDING          = C.GTK_SORT_DESCENDING
 )
 
+// Use as column id in SetSortColumnId to specify ListStore sorted
+// by default column or unsorted
+const (
+	SORT_COLUMN_DEFAULT  int = -1
+	SORT_COLUMN_UNSORTED int = -2
+)
+
 func marshalSortType(p uintptr) (interface{}, error) {
 	c := C.g_value_get_enum((*C.GValue)(unsafe.Pointer(p)))
 	return SortType(c), nil

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -4902,16 +4902,33 @@ func (v *ListStore) SetCols(iter *TreeIter, cols Cols) error {
 // Convenient map for Columns and values (See ListStore, TreeStore)
 type Cols map[int]interface{}
 
-// TODO(jrick)
-/*
-func (v *ListStore) InsertWithValues(iter *TreeIter, position int, columns []int, values []glib.Value) {
-		var ccolumns *C.gint
-		var cvalues *C.GValue
+// InsertWithValues() is a wrapper around gtk_list_store_insert_with_valuesv().
+func (v *ListStore) InsertWithValues(iter *TreeIter, position int, inColumns []int, inValues []interface{}) error {
+	length := len(inColumns)
+	if len(inValues) < length {
+		length = len(inValues)
+	}
 
-		C.gtk_list_store_insert_with_values(v.native(), iter.native(),
-			C.gint(position), columns, values, C.gint(len(values)))
+	var cColumns []C.gint
+	var cValues []C.GValue
+	for i := 0; i < length; i++ {
+		cColumns = append(cColumns, C.gint(inColumns[i]))
+
+		gv, err := glib.GValue(inValues[i])
+		if err != nil {
+			return err
+		}
+
+		var cvp *C.GValue = (*C.GValue)(gv.Native())
+		cValues = append(cValues, *cvp)
+	}
+	var cColumnsPointer *C.gint = &cColumns[0]
+	var cValuesPointer *C.GValue = &cValues[0]
+
+	C.gtk_list_store_insert_with_valuesv(v.native(), iter.native(), C.gint(position), cColumnsPointer, cValuesPointer, C.gint(length))
+
+	return nil
 }
-*/
 
 // InsertBefore() is a wrapper around gtk_list_store_insert_before().
 func (v *ListStore) InsertBefore(sibling *TreeIter) *TreeIter {


### PR DESCRIPTION
I am playing around with go and I am trying to implement a responsive UI where I need to insert large amounts of rows into a TreeView/ListStore. Scouring the Internet on how to achieve that I found several recommendations to use gtk_list_store_insert_with_values, which was not yet implemented in gotk3.

I have implemented the missing InsertWithValues wrapper by using gtk_list_store_insert_with_valuesv (instead of the varargs one). Keep in mind this is me touching go and cgo pretty much for the first time ever, so maybe you should take a closer look at it and tell me if my approach is correct.

I also added missing constants in this pull request as well, these are for setting a ListStore to unsorted or to sort by the default column. Setting a ListStore to unsorted is related to my problem of making it fast with lots of inserts.