### PR TITLE
Embed interfaces instead of structs for ActionGroup and ActionMap

### DIFF
--- a/glib/application.go
+++ b/glib/application.go
@@ -13,8 +13,8 @@ type Application struct {
 	*Object
 
 	// Interfaces
-	ActionMap
-	ActionGroup
+	IActionMap
+	IActionGroup
 }
 
 // native() returns a pointer to the underlying GApplication.
@@ -37,7 +37,7 @@ func marshalApplication(p uintptr) (interface{}, error) {
 func wrapApplication(obj *Object) *Application {
 	am := wrapActionMap(obj)
 	ag := wrapActionGroup(obj)
-	return &Application{obj, *am, *ag}
+	return &Application{obj, am, ag}
 }
 
 // ApplicationIDIsValid is a wrapper around g_application_id_is_valid().

--- a/glib/gactiongroup.go
+++ b/glib/gactiongroup.go
@@ -8,6 +8,21 @@ package glib
 import "C"
 import "unsafe"
 
+// IActionGroup is an interface representation of ActionGroup,
+// used to avoid duplication when embedding the type in a wrapper of another GObject-based type.
+type IActionGroup interface {
+	Native() uintptr
+
+	HasAction(actionName string) bool
+	GetActionEnabled(actionName string) bool
+	GetActionParameterType(actionName string) *VariantType
+	GetActionStateType(actionName string) *VariantType
+	GetActionState(actionName string) *Variant
+	GetActionStateHint(actionName string) *Variant
+	ChangeActionState(actionName string, value *Variant)
+	Activate(actionName string, parameter *Variant)
+}
+
 // ActionGroup is a representation of glib's GActionGroup GInterface
 type ActionGroup struct {
 	*Object

--- a/glib/gactionmap.go
+++ b/glib/gactionmap.go
@@ -8,6 +8,16 @@ package glib
 import "C"
 import "unsafe"
 
+// IActionMap is an interface representation of ActionMap,
+// used to avoid duplication when embedding the type in a wrapper of another GObject-based type.
+type IActionMap interface {
+	Native() uintptr
+
+	LookupAction(actionName string) *Action
+	AddAction(action IAction)
+	RemoveAction(actionName string)
+}
+
 // ActionMap is a representation of glib's GActionMap GInterface
 type ActionMap struct {
 	*Object

--- a/glib/gsimpleactiongroup.go
+++ b/glib/gsimpleactiongroup.go
@@ -15,8 +15,8 @@ type SimpleActionGroup struct {
 	*Object
 
 	// Interfaces
-	ActionMap
-	ActionGroup
+	IActionMap
+	IActionGroup
 }
 
 // deprecated since 2.38:
@@ -44,8 +44,8 @@ func marshalSimpleActionGroup(p uintptr) (interface{}, error) {
 }
 
 func wrapSimpleActionGroup(obj *Object) *SimpleActionGroup {
-	am := *wrapActionMap(obj)
-	ag := *wrapActionGroup(obj)
+	am := wrapActionMap(obj)
+	ag := wrapActionGroup(obj)
 	return &SimpleActionGroup{obj, am, ag}
 }
 

--- a/glib/gsimpleactiongroup_test.go
+++ b/glib/gsimpleactiongroup_test.go
@@ -1,0 +1,70 @@
+package glib
+
+import (
+	"testing"
+)
+
+func TestSimpleActionGroupNew(t *testing.T) {
+	sag := SimpleActionGroupNew()
+	if sag == nil {
+		t.Error("SimpleActionGroupNew returned nil")
+	}
+
+	if sag.IActionGroup == nil {
+		t.Error("Embedded IActionGroup is nil")
+	}
+	if sag.IActionMap == nil {
+		t.Error("Embedded IActionGroup is nil")
+	}
+}
+
+func TestSimpleActionGroup_AddAction_RemoveAction_HasAction(t *testing.T) {
+	sag := SimpleActionGroupNew()
+	if sag == nil {
+		t.Error("SimpleActionGroup returned nil")
+	}
+
+	// Check before: empty
+	hasAction := sag.HasAction("nope")
+	if hasAction {
+		t.Error("Action group contained unexpected action 'nope'")
+	}
+	hasAction = sag.HasAction("yepp")
+	if hasAction {
+		t.Error("Action group contained unexpected action 'yepp'")
+	}
+
+	// Add a new action
+	act := SimpleActionNew("yepp", nil)
+	if act == nil {
+		t.Error("SimpleActionNew returned nil")
+	}
+	sag.AddAction(act)
+
+	// Check that it exists
+	hasAction = sag.HasAction("nope")
+	if hasAction {
+		t.Error("Action group contained unexpected action 'nope'")
+	}
+	hasAction = sag.HasAction("yepp")
+	if !hasAction {
+		t.Error("Action group did not contain action 'yepp' after adding it")
+	}
+
+	// Remove the action again
+	sag.RemoveAction("yepp")
+
+	// Check that it was removed
+	hasAction = sag.HasAction("nope")
+	if hasAction {
+		t.Error("Action group contained unexpected action 'nope'")
+	}
+	hasAction = sag.HasAction("yepp")
+	if hasAction {
+		t.Error("Action group contained unexpected action 'yepp'")
+	}
+
+	// NoFail check: removing a non-existing action
+	sag.RemoveAction("yepp")
+	sag.RemoveAction("nope")
+}

--- a/gtk/application.go
+++ b/gtk/application.go
@@ -47,8 +47,8 @@ func marshalApplication(p uintptr) (interface{}, error) {
 }
 
 func wrapApplication(obj *glib.Object) *Application {
-	am := glib.ActionMap{obj}
-	ag := glib.ActionGroup{obj}
+	am := &glib.ActionMap{obj}
+	ag := &glib.ActionGroup{obj}
 	return &Application{glib.Application{obj, am, ag}}
 }
 

--- a/gtk/application_window.go
+++ b/gtk/application_window.go
@@ -21,8 +21,8 @@ type ApplicationWindow struct {
 	Window
 
 	// Interfaces
-	glib.ActionMap
-	glib.ActionGroup
+	glib.IActionMap
+	glib.IActionGroup
 }
 
 // native returns a pointer to the underlying GtkApplicationWindow.
@@ -41,8 +41,8 @@ func marshalApplicationWindow(p uintptr) (interface{}, error) {
 }
 
 func wrapApplicationWindow(obj *glib.Object) *ApplicationWindow {
-	am := glib.ActionMap{obj}
-	ag := glib.ActionGroup{obj}
+	am := &glib.ActionMap{obj}
+	ag := &glib.ActionGroup{obj}
 	return &ApplicationWindow{Window{Bin{Container{Widget{glib.InitiallyUnowned{obj}}}}}, am, ag}
 }
 


### PR DESCRIPTION
To avoid duplication of glib.Object functions when embedding ActionGroup and ActionMap in other types, this is the solution approach I outlined in #232.

In addition, this PR adds:
* Basic unit testing for SimpleActionGroup

Fixes #232 and fixes #249 