### PR TITLE
Add several missing functions added in GTK 3.12

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -3177,17 +3177,6 @@ func (v *Entry) SetWidthChars(nChars int) {
 	C.gtk_entry_set_width_chars(v.native(), C.gint(nChars))
 }
 
-// SetMaxWidthChars() is a wrapper around gtk_entry_set_max_width_chars().
-func (v *Entry) SetMaxWidthChars(nChars int) {
-	C.gtk_entry_set_max_width_chars(v.native(), C.gint(nChars))
-}
-
-// GetMaxWidthChars() is a wrapper around gtk_entry_get_max_width_chars().
-func (v *Entry) GetMaxWidthChars() int {
-	c := C.gtk_entry_get_max_width_chars(v.native())
-	return int(c)
-}
-
 // GetInvisibleChar() is a wrapper around gtk_entry_get_invisible_char().
 func (v *Entry) GetInvisibleChar() rune {
 	c := C.gtk_entry_get_invisible_char(v.native())

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -97,6 +97,7 @@ func init() {
 		{glib.Type(C.gtk_sort_type_get_type()), marshalSortType},
 		{glib.Type(C.gtk_state_flags_get_type()), marshalStateFlags},
 		{glib.Type(C.gtk_target_flags_get_type()), marshalTargetFlags},
+		{glib.Type(C.gtk_text_direction_get_type()), marshalTextDirection},
 		{glib.Type(C.gtk_toolbar_style_get_type()), marshalToolbarStyle},
 		{glib.Type(C.gtk_tree_model_flags_get_type()), marshalTreeModelFlags},
 		{glib.Type(C.gtk_window_position_get_type()), marshalWindowPosition},
@@ -758,6 +759,20 @@ const (
 func marshalStateFlags(p uintptr) (interface{}, error) {
 	c := C.g_value_get_enum((*C.GValue)(unsafe.Pointer(p)))
 	return StateFlags(c), nil
+}
+
+// TextDirection is a representation of GTK's GtkTextDirection.
+type TextDirection int
+
+const (
+	TEXT_DIR_NONE TextDirection = C.GTK_TEXT_DIR_NONE
+	TEXT_DIR_LTR  TextDirection = C.GTK_TEXT_DIR_LTR
+	TEXT_DIR_RTL  TextDirection = C.GTK_TEXT_DIR_RTL
+)
+
+func marshalTextDirection(p uintptr) (interface{}, error) {
+	c := C.g_value_get_enum((*C.GValue)(unsafe.Pointer(p)))
+	return TextDirection(c), nil
 }
 
 // TargetFlags is a representation of GTK's GtkTargetFlags.

--- a/gtk/gtk_since_3_12.go
+++ b/gtk/gtk_since_3_12.go
@@ -26,6 +26,12 @@ func init() {
 	WrapMap["GtkFlowBoxChild"] = wrapFlowBoxChild
 }
 
+// GetLocaleDirection() is a wrapper around gtk_get_locale_direction().
+func GetLocaleDirection() TextDirection {
+	c := C.gtk_get_locale_direction()
+	return TextDirection(c)
+}
+
 /*
  * Dialog
  */

--- a/gtk/gtk_since_3_12.go
+++ b/gtk/gtk_since_3_12.go
@@ -26,6 +26,25 @@ func init() {
 	WrapMap["GtkFlowBoxChild"] = wrapFlowBoxChild
 }
 
+/*
+ * Entry
+ */
+
+// SetMaxWidthChars() is a wrapper around gtk_entry_set_max_width_chars().
+func (v *Entry) SetMaxWidthChars(nChars int) {
+	C.gtk_entry_set_max_width_chars(v.native(), C.gint(nChars))
+}
+
+// GetMaxWidthChars() is a wrapper around gtk_entry_get_max_width_chars().
+func (v *Entry) GetMaxWidthChars() int {
+	c := C.gtk_entry_get_max_width_chars(v.native())
+	return int(c)
+}
+
+/*
+ * MenuButton
+ */
+
 // SetPopover is a wrapper around gtk_menu_button_set_popover().
 func (v *MenuButton) SetPopover(popover *Popover) {
 	C.gtk_menu_button_set_popover(v.native(), popover.toWidget())

--- a/gtk/gtk_since_3_12.go
+++ b/gtk/gtk_since_3_12.go
@@ -61,6 +61,34 @@ func (v *Entry) GetMaxWidthChars() int {
 }
 
 /*
+ * HeaderBar
+ */
+
+// GetDecorationLayout is a wrapper around gtk_header_bar_get_decoration_layout().
+func (v *HeaderBar) GetDecorationLayout() string {
+	c := C.gtk_header_bar_get_decoration_layout(v.native())
+	return C.GoString((*C.char)(c))
+}
+
+// SetDecorationLayout is a wrapper around gtk_header_bar_set_decoration_layout().
+func (v *HeaderBar) SetDecorationLayout(layout string) {
+	cstr := C.CString(layout)
+	defer C.free(unsafe.Pointer(cstr))
+	C.gtk_header_bar_set_decoration_layout(v.native(), (*C.gchar)(cstr))
+}
+
+// GetHasSubtitle is a wrapper around gtk_header_bar_get_has_subtitle().
+func (v *HeaderBar) GetHasSubtitle() bool {
+	c := C.gtk_header_bar_get_has_subtitle(v.native())
+	return gobool(c)
+}
+
+// SetHasSubtitle is a wrapper around gtk_header_bar_set_has_subtitle().
+func (v *HeaderBar) SetHasSubtitle(setting bool) {
+	C.gtk_header_bar_set_has_subtitle(v.native(), gbool(setting))
+}
+
+/*
  * MenuButton
  */
 

--- a/gtk/gtk_since_3_12.go
+++ b/gtk/gtk_since_3_12.go
@@ -27,6 +27,19 @@ func init() {
 }
 
 /*
+ * Dialog
+ */
+
+// GetHeaderBar is a wrapper around gtk_dialog_get_header_bar().
+func (v *Dialog) GetHeaderBar() *Widget {
+	c := C.gtk_dialog_get_header_bar(v.native())
+	if c == nil {
+		return nil
+	}
+	return wrapWidget(glib.Take(unsafe.Pointer(c)))
+}
+
+/*
  * Entry
  */
 

--- a/gtk/gtk_since_3_12.go
+++ b/gtk/gtk_since_3_12.go
@@ -106,6 +106,17 @@ func (v *MenuButton) GetPopover() *Popover {
 	return wrapPopover(glib.Take(unsafe.Pointer(c)))
 }
 
+// GetUsePopover is a wrapper around gtk_menu_button_get_use_popover().
+func (v *MenuButton) GetUsePopover() bool {
+	c := C.gtk_menu_button_get_use_popover(v.native())
+	return gobool(c)
+}
+
+// SetUsePopover is a wrapper around gtk_menu_button_set_use_popover().
+func (v *MenuButton) SetUsePopover(setting bool) {
+	C.gtk_menu_button_set_use_popover(v.native(), gbool(setting))
+}
+
 /*
  * FlowBox
  */

--- a/gtk/gtk_since_3_12.go
+++ b/gtk/gtk_since_3_12.go
@@ -4,6 +4,7 @@
 package gtk
 
 // #cgo pkg-config: gtk+-3.0
+// #include <stdlib.h>
 // #include <gtk/gtk.h>
 // #include "gtk_since_3_12.go.h"
 import "C"

--- a/gtk/stack_since_3_12.go
+++ b/gtk/stack_since_3_12.go
@@ -27,3 +27,9 @@ func (v *Stack) GetChildByName(name string) *Widget {
 	}
 	return wrapWidget(glib.Take(unsafe.Pointer(c)))
 }
+
+// GetTransitionRunning is a wrapper around gtk_stack_get_transition_running().
+func (v *Stack) GetTransitionRunning() bool {
+	c := C.gtk_stack_get_transition_running(v.native())
+	return gobool(c)
+}


### PR DESCRIPTION
Includes:
* Entry.{Get,Set}MaxWidthChars() in proper location ( supersedes and closes #202 )
* Dialog.GetHeaderBar()
* GtkTextDirection enum (not added in 3.12, but required for one of the functions)
* GetLocaleDirection()
* HeaderBar.{Get,Set}DecorationLayout()
* HeaderBar.{Get,Set}HasSubtitle()
* MenuButton.{Get,Set}UsePopover()
* Stack.GetTransitionRunning()