### PR TITLE
Let InsertActionGroup take IActionGroup.

### DIFF
--- a/gtk/widget.go
+++ b/gtk/widget.go
@@ -625,6 +625,6 @@ func (v *Widget) GetPreferredWidth() (int, int) {
 	return int(minimum), int(natural)
 }
 
-func (v *Widget) InsertActionGroup(name string, group *glib.ActionGroup) {
+func (v *Widget) InsertActionGroup(name string, group glib.IActionGroup) {
 	C.gtk_widget_insert_action_group(v.native(), (*C.gchar)(C.CString(name)), C.toGActionGroup(unsafe.Pointer(group.Native())))
 }


### PR DESCRIPTION
It is currently not possible to pass a SimpleActionGroup to InsertActionGroup, because it only takes the ActionGroup concrete type.