### PR TITLE
Add a wrapper around cairo_surface_write_to_png.

### DIFF
--- a/cairo/surface.go
+++ b/cairo/surface.go
@@ -208,6 +208,21 @@ func (v *Surface) GetMimeData(mimeType MimeType) []byte {
 	return C.GoBytes(unsafe.Pointer(data), C.int(length))
 }
 
+// WriteToPNG is a wrapper around cairo_surface_write_png(). It writes the Cairo
+// surface to the given file in PNG format.
+func (v *Surface) WriteToPNG(fileName string) error {
+	cstr := C.CString(fileName)
+	defer C.free(unsafe.Pointer(cstr))
+
+	status := Status(C.cairo_surface_write_to_png(v.surface, cstr))
+
+	if status != STATUS_SUCCESS {
+		return ErrorStatus(status)
+	}
+
+	return nil
+}
+
 // TODO(jrick) SupportsMimeType (since 1.12)
 
 // TODO(jrick) MapToImage (since 1.12)


### PR DESCRIPTION
I am working on a binding for librsvg. One common use case is to use librsvg + Cairo to convert SVGs to various other formats. This commit adds the `WriteToPNG` method to `Surface`.

The cairo package currently already assumes that PNG support is built in (per `NewSurfaceFromPNG`).