### PR TITLE
Add a constructor for creating PDF surfaces.

### DIFF
--- a/cairo/canvas.go
+++ b/cairo/canvas.go
@@ -49,6 +49,11 @@ func WrapContext(p uintptr) *Context {
 	return wrapContext(context)
 }
 
+// Closes the context. The context must not be used afterwards.
+func (v *Context) Close() {
+	v.destroy()
+}
+
 // Create is a wrapper around cairo_create().
 func Create(target *Surface) *Context {
 	c := C.cairo_create(target.native())
@@ -64,7 +69,10 @@ func (v *Context) reference() {
 
 // destroy is a wrapper around cairo_destroy().
 func (v *Context) destroy() {
-	C.cairo_destroy(v.native())
+	if v.context != nil {
+		C.cairo_destroy(v.native())
+		v.context = nil
+	}
 }
 
 // Status is a wrapper around cairo_status().


### PR DESCRIPTION
PDF surfaces and associated contexts should be closed properly or they
will result in an empty or otherwise invalid PDF file. Since finalizers
are not guaranteed to run in Go, an explicit Close() method is required
to guarantee the proper closure of contexts and surfaces.