### PR TITLE
cairo.Pattern: Clean code and use Status.ToError

### DIFF
--- a/cairo/canvas.go
+++ b/cairo/canvas.go
@@ -126,6 +126,11 @@ func (v *Context) GetGroupTarget() *Surface {
 	return s
 }
 
+// SetSource is a wrapper around cairo_set_source().
+func (v *Context) SetSource(p *Pattern) {
+	C.cairo_set_source(v.native(), p.native())
+}
+
 // SetSourceRGB is a wrapper around cairo_set_source_rgb().
 func (v *Context) SetSourceRGB(red, green, blue float64) {
 	C.cairo_set_source_rgb(v.native(), C.double(red), C.double(green),
@@ -411,4 +416,13 @@ func (v *Context) CopyPage() {
 // ShowPage is a wrapper around cairo_show_page().
 func (v *Context) ShowPage() {
 	C.cairo_show_page(v.native())
+}
+
+// IdentityMatrix is a wrapper around cairo_identity_matrix().
+//
+// Resets the current transformation matrix (CTM) by setting it equal to the
+// identity matrix. That is, the user-space and device-space axes will be
+// aligned and one user-space unit will transform to one device-space unit.
+func (v *Context) IdentityMatrix() {
+	C.cairo_identity_matrix(v.native())
 }

--- a/cairo/status.go
+++ b/cairo/status.go
@@ -6,6 +6,8 @@ package cairo
 // #include <cairo-gobject.h>
 import "C"
 import (
+	"errors"
+	"strings"
 	"unsafe"
 )
 
@@ -94,16 +96,30 @@ var key_Status = map[Status]string{
 }
 
 func StatusToString(status Status) string {
-
 	s, ok := key_Status[status]
 	if !ok {
 		s = "CAIRO_STATUS_UNDEFINED"
 	}
-
 	return s
 }
 
 func marshalStatus(p uintptr) (interface{}, error) {
 	c := C.g_value_get_enum((*C.GValue)(unsafe.Pointer(p)))
 	return Status(c), nil
+}
+
+// String returns a readable status messsage usable in texts.
+func (s Status) String() string {
+	str := StatusToString(s)
+	str = strings.Replace(str, "CAIRO_STATUS_", "", 1)
+	str = strings.Replace(str, "_", " ", 0)
+	return strings.ToLower(str)
+}
+
+// ToError returns the error for the status. Returns nil if success.
+func (s Status) ToError() error {
+	if s == STATUS_SUCCESS {
+		return nil
+	}
+	return errors.New(s.String())
 }


### PR DESCRIPTION
cairo.Status: added method ToError, converting the error message to go standards (lowercaps)