### PR TITLE
Implement cairo context matrix

### DIFF
--- a/cairo/canvas.go
+++ b/cairo/canvas.go
@@ -417,12 +417,3 @@ func (v *Context) CopyPage() {
 func (v *Context) ShowPage() {
 	C.cairo_show_page(v.native())
 }
-
-// IdentityMatrix is a wrapper around cairo_identity_matrix().
-//
-// Resets the current transformation matrix (CTM) by setting it equal to the
-// identity matrix. That is, the user-space and device-space axes will be
-// aligned and one user-space unit will transform to one device-space unit.
-func (v *Context) IdentityMatrix() {
-	C.cairo_identity_matrix(v.native())
-}

--- a/cairo/translations.go
+++ b/cairo/translations.go
@@ -21,12 +21,59 @@ func (v *Context) Rotate(angle float64) {
 	C.cairo_rotate(v.native(), C.double(angle))
 }
 
-// TODO: The following depend on cairo_matrix_t:
-//void 	cairo_transform ()
-//void 	cairo_set_matrix ()
-//void 	cairo_get_matrix ()
-//void 	cairo_identity_matrix ()
-//void 	cairo_user_to_device ()
-//void 	cairo_user_to_device_distance ()
-//void 	cairo_device_to_user ()
-//void 	cairo_device_to_user_distance ()
+// Transform is a wrapper around cairo_transform.
+func (v *Context) Transform(matrix *Matrix) {
+	C.cairo_transform(v.native(), matrix.Native())
+}
+
+// SetMatrix is a wrapper around cairo_set_matrix.
+func (v *Context) SetMatrix(matrix *Matrix) {
+	C.cairo_set_matrix(v.native(), matrix.Native())
+}
+
+// GetMatrix is a wrapper around cairo_get_matrix.
+func (v *Context) GetMatrix() *Matrix {
+	var matrix C.cairo_matrix_t
+	C.cairo_get_matrix(v.native(), &matrix)
+	return &Matrix{
+		Xx: float64(matrix.xx),
+		Yx: float64(matrix.yx),
+		Xy: float64(matrix.xy),
+		Yy: float64(matrix.yy),
+		X0: float64(matrix.x0),
+		Y0: float64(matrix.y0),
+	}
+}
+
+// IdentityMatrix is a wrapper around cairo_identity_matrix().
+//
+// Resets the current transformation matrix (CTM) by setting it equal to the
+// identity matrix. That is, the user-space and device-space axes will be
+// aligned and one user-space unit will transform to one device-space unit.
+func (v *Context) IdentityMatrix() {
+	C.cairo_identity_matrix(v.native())
+}
+
+// UserToDevice is a wrapper around cairo_user_to_device.
+func (v *Context) UserToDevice(x, y float64) (float64, float64) {
+	C.cairo_user_to_device(v.native(), (*C.double)(&x), (*C.double)(&y))
+	return x, y
+}
+
+// UserToDeviceDistance is a wrapper around cairo_user_to_device_distance.
+func (v *Context) UserToDeviceDistance(dx, dy float64) (float64, float64) {
+	C.cairo_user_to_device_distance(v.native(), (*C.double)(&dx), (*C.double)(&dy))
+	return dx, dy
+}
+
+// DeviceToUser  is a wrapper around cairo_device_to_user.
+func (v *Context) DeviceToUser(x, y float64) (float64, float64) {
+	C.cairo_device_to_user(v.native(), (*C.double)(&x), (*C.double)(&y))
+	return x, y
+}
+
+// DeviceToUserDistance is a wrapper around cairo_device_to_user_distance.
+func (v *Context) DeviceToUserDistance(x, y float64) (float64, float64) {
+	C.cairo_device_to_user_distance(v.native(), (*C.double)(&x), (*C.double)(&y))
+	return x, y
+}

--- a/matrix.go
+++ b/matrix.go
@@ -1,0 +1,91 @@
+package cairo
+
+// #include <cairo/cairo.h>
+import "C"
+
+import (
+	"unsafe"
+)
+
+// Matrix struct
+type Matrix struct {
+	Xx, Yx float64
+	Xy, Yy float64
+	X0, Y0 float64
+}
+
+// NewMatrix creates a new identiy matrix
+func NewMatrix(xx, yx, xy, yy, x0, y0 float64) *Matrix {
+	return &Matrix{
+		Xx: xx,
+		Yx: yx,
+		Xy: xy,
+		Yy: yy,
+		X0: x0,
+		Y0: y0,
+	}
+}
+
+// Native returns native c pointer to a matrix
+func (m *Matrix) Native() *C.cairo_matrix_t {
+	return (*C.cairo_matrix_t)(unsafe.Pointer(m))
+}
+
+// InitIdentity initializes this matrix to identity matrix
+func (m *Matrix) InitIdentity() {
+	C.cairo_matrix_init_identity(m.Native())
+}
+
+// InitTranslate initializes a matrix with the given translation
+func (m *Matrix) InitTranslate(tx, ty float64) {
+	C.cairo_matrix_init_translate(m.Native(), C.double(tx), C.double(ty))
+}
+
+// InitScale initializes a matrix with the give scale
+func (m *Matrix) InitScale(sx, sy float64) {
+	C.cairo_matrix_init_scale(m.Native(), C.double(sx), C.double(sy))
+}
+
+// InitRotate initializes a matrix with the given rotation
+func (m *Matrix) InitRotate(radians float64) {
+	C.cairo_matrix_init_rotate(m.Native(), C.double(radians))
+}
+
+// Translate translates a matrix by the given amount
+func (m *Matrix) Translate(tx, ty float64) {
+	C.cairo_matrix_translate(m.Native(), C.double(tx), C.double(ty))
+}
+
+// Scale scales the matrix by the given amounts
+func (m *Matrix) Scale(sx, sy float64) {
+	C.cairo_matrix_scale(m.Native(), C.double(sx), C.double(sy))
+}
+
+// Rotate rotates the matrix by the given amount
+func (m *Matrix) Rotate(radians float64) {
+	C.cairo_matrix_rotate(m.Native(), C.double(radians))
+}
+
+// Invert inverts the matrix
+func (m *Matrix) Invert() {
+	C.cairo_matrix_invert(m.Native())
+}
+
+// Multiply multiplies the matrix by another matrix
+func (m *Matrix) Multiply(a, b Matrix) {
+	C.cairo_matrix_multiply(m.Native(), a.Native(), b.Native())
+}
+
+// TransformDistance ...
+func (m *Matrix) TransformDistance(dx, dy float64) (float64, float64) {
+	C.cairo_matrix_transform_distance(m.Native(),
+		(*C.double)(unsafe.Pointer(&dx)), (*C.double)(unsafe.Pointer(&dy)))
+	return dx, dy
+}
+
+// TransformPoint ...
+func (m *Matrix) TransformPoint(x, y float64) (float64, float64) {
+	C.cairo_matrix_transform_point(m.Native(),
+		(*C.double)(unsafe.Pointer(&x)), (*C.double)(unsafe.Pointer(&y)))
+	return x, y
+}


### PR DESCRIPTION
Added matrix.go for cairo_matrix_t binding. Implemented missing context translation methods in translations.go

Some of this was taken from github.com/ungerik/go-cairo, but fleshed out a lot more than what is there and cleaned up. Most of it is also implemented in my own fork of go-cairo at github.com/bit101/go-cairo since ungerik's is not in active development in 2 years.