### PR TITLE
Add bindings for GtkShortcutsWindow

### DIFF
--- a/gtk/gtk.go.h
+++ b/gtk/gtk.go.h
@@ -328,6 +328,12 @@ toGtkMenuBar(void *p)
 	return (GTK_MENU_BAR(p));
 }
 
+static GtkShortcutsWindow *
+toGtkShortcutsWindow(void *p)
+{
+	return (GTK_SHORTCUTS_WINDOW(p));
+}
+
 static GtkSizeGroup *
 toGtkSizeGroup(void *p)
 {

--- a/gtk/settingswindow.go
+++ b/gtk/settingswindow.go
@@ -1,0 +1,47 @@
+package gtk
+
+// #include <gtk/gtk.h>
+// #include "gtk.go.h"
+import "C"
+import (
+	"unsafe"
+
+	"github.com/gotk3/gotk3/glib"
+)
+
+func init() {
+	tm := []glib.TypeMarshaler{
+		{glib.Type(C.gtk_shortcuts_window_get_type()), marshalShortcutsWindow},
+	}
+
+	glib.RegisterGValueMarshalers(tm)
+
+	WrapMap["GtkShortcutsWindow"] = wrapShortcutsWindow
+}
+
+/*
+ * GtkShortcutsWindow
+ */
+
+// ShortcutsWindow is a representation of GTK's GtkShortcutsWindow.
+type ShortcutsWindow struct {
+	Window
+}
+
+func (v *ShortcutsWindow) native() *C.GtkShortcutsWindow {
+	if v == nil || v.GObject == nil {
+		return nil
+	}
+	p := unsafe.Pointer(v.GObject)
+	return C.toGtkShortcutsWindow(p)
+}
+
+func marshalShortcutsWindow(p uintptr) (interface{}, error) {
+	c := C.g_value_get_object((*C.GValue)(unsafe.Pointer(p)))
+	obj := glib.Take(unsafe.Pointer(c))
+	return wrapShortcutsWindow(obj), nil
+}
+
+func wrapShortcutsWindow(obj *glib.Object) *ShortcutsWindow {
+	return &ShortcutsWindow{Window{Bin{Container{Widget{glib.InitiallyUnowned{obj}}}}}}
+}


### PR DESCRIPTION
Added `SettingsWindow` type.

Example:

```GO
package main

import (
	"github.com/gotk3/gotk3/gtk"
)

func main() {
	gtk.Init(nil)

	builder, _ := gtk.BuilderNew()
	//Add file content as multilinestring: http://gitlab.gnome.org/GNOME/gtk/raw/gtk-3-22/demos/gtk-demo/shortcuts-gedit.ui
	builder.AddFromString(...)

	window, _ := builder.GetObject("shortcuts-gedit")
	windowCast, ok := window.(*gtk.ShortcutsWindow)
	if ok {
		windowCast.SetResizable(true)
		windowCast.ShowAll()
	} else {
		panic("Invalid type")
	}

	gtk.Main()
}
```