### PR TITLE
Add bindings for GtkShortcutsWindow

### DIFF
--- a/gtk/shortcutswindow_since_3_22.go
+++ b/gtk/shortcutswindow_since_3_22.go
@@ -1,0 +1,50 @@
+// +build !gtk_3_6,!gtk_3_8,!gtk_3_10,!gtk_3_12,!gtk_3_14,!gtk_3_16,!gtk_3_18,!gtk_3_20
+
+package gtk
+
+// #include <gtk/gtk.h>
+// #include "gtk.go.h"
+// #include "shortcutswindow_since_3_22.go.h"
+import "C"
+import (
+	"unsafe"
+
+	"github.com/gotk3/gotk3/glib"
+)
+
+func init() {
+	tm := []glib.TypeMarshaler{
+		{glib.Type(C.gtk_shortcuts_window_get_type()), marshalShortcutsWindow},
+	}
+
+	glib.RegisterGValueMarshalers(tm)
+
+	WrapMap["GtkShortcutsWindow"] = wrapShortcutsWindow
+}
+
+/*
+ * GtkShortcutsWindow
+ */
+
+// ShortcutsWindow is a representation of GTK's GtkShortcutsWindow.
+type ShortcutsWindow struct {
+	Window
+}
+
+func (v *ShortcutsWindow) native() *C.GtkShortcutsWindow {
+	if v == nil || v.GObject == nil {
+		return nil
+	}
+	p := unsafe.Pointer(v.GObject)
+	return C.toGtkShortcutsWindow(p)
+}
+
+func marshalShortcutsWindow(p uintptr) (interface{}, error) {
+	c := C.g_value_get_object((*C.GValue)(unsafe.Pointer(p)))
+	obj := glib.Take(unsafe.Pointer(c))
+	return wrapShortcutsWindow(obj), nil
+}
+
+func wrapShortcutsWindow(obj *glib.Object) *ShortcutsWindow {
+	return &ShortcutsWindow{Window{Bin{Container{Widget{glib.InitiallyUnowned{obj}}}}}}
+}

--- a/gtk/shortcutswindow_since_3_22.go.h
+++ b/gtk/shortcutswindow_since_3_22.go.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2013-2014 Conformal Systems <info@conformal.com>
+ *
+ * This file originated from: http://opensource.conformal.com/
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+static GtkShortcutsWindow *
+toGtkShortcutsWindow(void *p)
+{
+	return (GTK_SHORTCUTS_WINDOW(p));
+}


### PR DESCRIPTION
Added `ShortcutsWindow` type.

Example:

```GO
package main

import (
	"github.com/gotk3/gotk3/gtk"
)

func main() {
	gtk.Init(nil)

	builder, _ := gtk.BuilderNew()
	//Add file content as multilinestring: http://gitlab.gnome.org/GNOME/gtk/raw/gtk-3-22/demos/gtk-demo/shortcuts-gedit.ui
	builder.AddFromString(...)

	window, _ := builder.GetObject("shortcuts-gedit")
	windowCast, ok := window.(*gtk.ShortcutsWindow)
	if ok {
		windowCast.SetResizable(true)
		windowCast.ShowAll()
	} else {
		panic("Invalid type")
	}

	gtk.Main()
}
```

This is my 2. attempt, I already had a "fucked up" PR, which I closed: https://github.com/gotk3/gotk3/pull/291

Hope I didn't get it wrong, but afaik it has been added in 3.22, at least according to the commit: https://github.com/GNOME/gtk/commit/1dfbae1aa41bb2b3b95fa841e0c1707fab52ca8b

Please correct me if I am wrong :)