### PR TITLE
Add glib.Menu.*SectionWithoutLabel() for unlabeled menu sections.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ sudo: required
 dist: trusty
 
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq -y gtk+3.0 libgtk-3-dev
-  - sudo apt-get install -qq -y xvfb
+  - sudo apt-get update
+  - sudo apt-get install -y gtk+3.0 libgtk-3-dev
+  - sudo apt-get install -y xvfb
   - "export DISPLAY=:99.0"
   - sudo /usr/bin/Xvfb $DISPLAY 2>1 > /dev/null &
   - "export GTK_VERSION=$(pkg-config --modversion gtk+-3.0 | tr . _| cut -d '_' -f 1-2)"

--- a/glib/menu.go
+++ b/glib/menu.go
@@ -174,6 +174,24 @@ func (v *Menu) AppendSection(label string, section *MenuModel) {
 	C.g_menu_append_section(v.native(), cstr1, section.native())
 }
 
+// InsertSectionWithoutLabel is a wrapper around g_menu_insert_section()
+// with label set to null.
+func (v *Menu) InsertSectionWithoutLabel(position int, section *MenuModel) {
+	C.g_menu_insert_section(v.native(), C.gint(position), nil, section.native())
+}
+
+// PrependSectionWithoutLabel is a wrapper around
+// g_menu_prepend_section() with label set to null.
+func (v *Menu) PrependSectionWithoutLabel(section *MenuModel) {
+	C.g_menu_prepend_section(v.native(), nil, section.native())
+}
+
+// AppendSectionWithoutLabel is a wrapper around g_menu_append_section()
+// with label set to null.
+func (v *Menu) AppendSectionWithoutLabel(section *MenuModel) {
+	C.g_menu_append_section(v.native(), nil, section.native())
+}
+
 // InsertSubmenu is a wrapper around g_menu_insert_submenu().
 func (v *Menu) InsertSubmenu(position int, label string, submenu *MenuModel) {
 	cstr1 := (*C.gchar)(C.CString(label))


### PR DESCRIPTION
`g_menu_{insert,prepend,append}_section` allows `label` to be `NULL` as a way to create an unlabeled section within a menu. Since go strings cannot be nil, creating unlabeled sections is currently not possible. This pull request adds new `glib.Menu` methods `InsertSectionWithoutLabel`, `PrependSectionWithoutLabel`, and `AppendSectionWithoutLabel` to allow adding unlabeled sections to a `glib.Menu`.