### PR TITLE
Add TextChildAnchor, TextBuffer.CreateChildAnchor, TextView.AddChildAtAnchor

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -7525,6 +7525,14 @@ func (v *TextBuffer) ApplyTagByName(name string, start, end *TextIter) {
 		(*C.GtkTextIter)(start), (*C.GtkTextIter)(end))
 }
 
+// CreateChildAnchor() is a wrapper around gtk_text_buffer_create_child_anchor().
+// Since it copies garbage from the stack into the padding bytes of iter,
+// iter can't be reliably reused after this call unless GODEBUG=cgocheck=0.
+func (v *TextBuffer) CreateChildAnchor(iter *TextIter) *TextChildAnchor {
+	ret := C.gtk_text_buffer_create_child_anchor(v.native(), iter.native())
+	return (*TextChildAnchor)(ret)
+}
+
 // Delete() is a wrapper around gtk_text_buffer_delete().
 func (v *TextBuffer) Delete(start, end *TextIter) {
 	C.gtk_text_buffer_delete(v.native(), (*C.GtkTextIter)(start), (*C.GtkTextIter)(end))

--- a/gtk/text_child_anchor.go
+++ b/gtk/text_child_anchor.go
@@ -1,0 +1,19 @@
+// Same copyright and license as the rest of the files in this project
+
+package gtk
+
+// #include <gtk/gtk.h>
+// #include "gtk.go.h"
+import "C"
+
+/*
+ * GtkTextChildAnchor
+ */
+
+// TextChildAnchor is a representation of GTK's GtkTextChildAnchor
+type TextChildAnchor C.GtkTextChildAnchor
+
+// native returns a pointer to the underlying GtkTextChildAnchor.
+func (v *TextChildAnchor) native() *C.GtkTextChildAnchor {
+	return (*C.GtkTextChildAnchor)(v)
+}

--- a/gtk/text_view.go
+++ b/gtk/text_view.go
@@ -401,6 +401,11 @@ func (v *TextView) ResetImContext() {
 	C.gtk_text_view_reset_im_context(v.native())
 }
 
+// AddChildAtAnchor is a wrapper around gtk_text_view_add_child_at_anchor().
+func (v *TextView) AddChildAtAnchor(child IWidget, anchor *TextChildAnchor) {
+	C.gtk_text_view_add_child_at_anchor(v.native(), child.toWidget(), anchor.native())
+}
+
 // GtkAdjustment * 	gtk_text_view_get_hadjustment ()  -- DEPRECATED
 // GtkAdjustment * 	gtk_text_view_get_vadjustment ()  -- DEPRECATED
 // void 	gtk_text_view_add_child_at_anchor ()


### PR DESCRIPTION
Wrap `GtkTextChildAnchor`, `gtk_text_buffer_create_child_anchor`, `gtk_text_view_add_child_at_anchor`.

---

The `iter` passed to `TextBuffer.CreateChildAnchor` is mangled in this call chain:

`gtk_text_buffer_create_child_anchor` at [gtktextbuffer.c:2024](https://gitlab.gnome.org/GNOME/gtk/blob/3.22.30/gtk/gtktextbuffer.c#L2024)
`g_signal_emit`
`g_signal_emit_valist`
`_g_closure_invoke_va`
`_gtk_marshal_VOID__BOXED_OBJECTv` at [gtkmarshalers.c:3131](https://gitlab.gnome.org/GNOME/gtk/blob/3.22.30/gtk/gtkmarshalers.c#L3131)
`gtk_text_buffer_real_insert_anchor` at [gtktextbuffer.c:1962](https://gitlab.gnome.org/GNOME/gtk/blob/3.22.30/gtk/gtktextbuffer.c#L1962)
`_gtk_text_btree_insert_child_anchor` at [gtktextbtree.c:1335](https://gitlab.gnome.org/GNOME/gtk/blob/3.22.30/gtk/gtktextbtree.c#L1335)
`insert_pixbuf_or_widget_segment` at [gtktextbtree.c:1299](https://gitlab.gnome.org/GNOME/gtk/blob/3.22.30/gtk/gtktextbtree.c#L1299)

since `insert_pixbuf_or_widget_segment` creates `GtkTextIter start` on the stack and does not zero fill it before partially initializing it and copying to iter.