### PR TITLE
Sync functions deprecated since 3.16, 3.24 with corresponding build tags

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -2634,30 +2634,6 @@ func GdkCairoSetSourcePixBuf(cr *cairo.Context, pixbuf *gdk.Pixbuf, pixbufX, pix
 	C.gdk_cairo_set_source_pixbuf(context, ptr, C.gdouble(pixbufX), C.gdouble(pixbufY))
 }
 
-// GetFocusChain is a wrapper around gtk_container_get_focus_chain().
-func (v *Container) GetFocusChain() ([]*Widget, bool) {
-	var cwlist *C.GList
-	c := C.gtk_container_get_focus_chain(v.native(), &cwlist)
-
-	var widgets []*Widget
-	wlist := glib.WrapList(uintptr(unsafe.Pointer(cwlist)))
-	for ; wlist.Data() != nil; wlist = wlist.Next() {
-		widgets = append(widgets, wrapWidget(glib.Take(wlist.Data().(unsafe.Pointer))))
-	}
-	return widgets, gobool(c)
-}
-
-// SetFocusChain is a wrapper around gtk_container_set_focus_chain().
-func (v *Container) SetFocusChain(focusableWidgets []IWidget) {
-	var list *glib.List
-	for _, w := range focusableWidgets {
-		data := uintptr(unsafe.Pointer(w.toWidget()))
-		list = list.Append(data)
-	}
-	glist := (*C.GList)(unsafe.Pointer(list))
-	C.gtk_container_set_focus_chain(v.native(), glist)
-}
-
 /*
  * GtkCssProvider
  */
@@ -2728,17 +2704,6 @@ func (v *CssProvider) ToString() (string, error) {
 		return "", nilPtrErr
 	}
 	return C.GoString(c), nil
-}
-
-// CssProviderGetDefault is a wrapper around gtk_css_provider_get_default().
-func CssProviderGetDefault() (*CssProvider, error) {
-	c := C.gtk_css_provider_get_default()
-	if c == nil {
-		return nil, nilPtrErr
-	}
-
-	obj := glib.Take(unsafe.Pointer(c))
-	return wrapCssProvider(obj), nil
 }
 
 // GetNamed is a wrapper around gtk_css_provider_get_named().

--- a/gtk/gtk_deprecated_since_3_16.go
+++ b/gtk/gtk_deprecated_since_3_16.go
@@ -22,6 +22,14 @@ func (v *Widget) OverrideColor(state StateFlags, color *gdk.RGBA) {
 	C.gtk_widget_override_color(v.native(), C.GtkStateFlags(state), cColor)
 }
 
+func (v *Widget) OverrideBackgroundColor(state StateFlags, color *gdk.RGBA) {
+	var cColor *C.GdkRGBA
+	if color != nil {
+		cColor = (*C.GdkRGBA)(unsafe.Pointer(color.Native()))
+	}
+	C.gtk_widget_override_background_color(v.native(), C.GtkStateFlags(state), cColor)
+}
+
 // OverrideFont is a wrapper around gtk_widget_override_font().
 func (v *Widget) OverrideFont(description string) {
 	cstr := C.CString(description)

--- a/gtk/gtk_deprecated_since_3_16.go
+++ b/gtk/gtk_deprecated_since_3_16.go
@@ -30,10 +30,18 @@ func (v *Widget) OverrideBackgroundColor(state StateFlags, color *gdk.RGBA) {
 	C.gtk_widget_override_background_color(v.native(), C.GtkStateFlags(state), cColor)
 }
 
+func (v *Button) SetColor(color string) {
+	v.OverrideBackgroundColor(gtk.STATE_FLAG_NORMAL, color)
+}
+
 // OverrideFont is a wrapper around gtk_widget_override_font().
 func (v *Widget) OverrideFont(description string) {
 	cstr := C.CString(description)
 	defer C.free(unsafe.Pointer(cstr))
 	c := C.pango_font_description_from_string(cstr)
 	C.gtk_widget_override_font(v.native(), c)
+}
+
+func (v *Label) SetFont(font string) {
+	v.OverrideFont(font)
 }

--- a/gtk/gtk_deprecated_since_3_16.go
+++ b/gtk/gtk_deprecated_since_3_16.go
@@ -31,7 +31,9 @@ func (v *Widget) OverrideBackgroundColor(state StateFlags, color *gdk.RGBA) {
 }
 
 func (v *Button) SetColor(color string) {
-	v.OverrideBackgroundColor(gtk.STATE_FLAG_NORMAL, color)
+	rgba := C.GdkRGBA{}
+	C.gdk_rgba_parse(&rgba, (*C.gchar)(C.CString(color)))
+	C.gtk_widget_override_background_color(v.toWidget(), C.GTK_STATE_FLAG_NORMAL, &rgba)
 }
 
 // OverrideFont is a wrapper around gtk_widget_override_font().

--- a/gtk/gtk_deprecated_since_3_24.go
+++ b/gtk/gtk_deprecated_since_3_24.go
@@ -1,0 +1,47 @@
+//+build gtk_3_6 gtk_3_8 gtk_3_10 gtk_3_12 gtk_3_14 gtk_3_16 gtk_3_18 gtk_3_20 gtk_3_22
+
+package gtk
+
+// #cgo pkg-config: gtk+-3.0
+// #include <gtk/gtk.h>
+// #include <stdlib.h>
+import "C"
+import (
+	"unsafe"
+
+	"github.com/gotk3/gotk3/glib"
+)
+
+// GetFocusChain is a wrapper around gtk_container_get_focus_chain().
+func (v *Container) GetFocusChain() ([]*Widget, bool) {
+	var cwlist *C.GList
+	c := C.gtk_container_get_focus_chain(v.native(), &cwlist)
+
+	var widgets []*Widget
+	wlist := glib.WrapList(uintptr(unsafe.Pointer(cwlist)))
+	for ; wlist.Data() != nil; wlist = wlist.Next() {
+		widgets = append(widgets, wrapWidget(glib.Take(wlist.Data().(unsafe.Pointer))))
+	}
+	return widgets, gobool(c)
+}
+
+// SetFocusChain is a wrapper around gtk_container_set_focus_chain().
+func (v *Container) SetFocusChain(focusableWidgets []IWidget) {
+	var list *glib.List
+	for _, w := range focusableWidgets {
+		data := uintptr(unsafe.Pointer(w.toWidget()))
+		list = list.Append(data)
+	}
+	glist := (*C.GList)(unsafe.Pointer(list))
+	C.gtk_container_set_focus_chain(v.native(), glist)
+}
+
+// CssProviderGetDefault is a wrapper around gtk_css_provider_get_default().
+func CssProviderGetDefault() (*CssProvider, error) {
+	c := C.gtk_css_provider_get_default()
+	if c == nil {
+		return nil, nilPtrErr
+	}
+	obj := glib.Take(unsafe.Pointer(c))
+	return wrapCssProvider(obj), nil
+}

--- a/gtk/gtk_since_3_20.go
+++ b/gtk/gtk_since_3_20.go
@@ -206,9 +206,3 @@ func (v *FileChooserNativeDialog) SetCancelLabel(cancel_label string) {
 func (v *FileChooserNativeDialog) GetCancelLabel() (string, error) {
 	return stringReturn((*C.gchar)(C.gtk_file_chooser_native_get_cancel_label(v.native())))
 }
-
-func (v *Button) SetColor(color string) {
-	rgba := C.GdkRGBA{}
-	C.gdk_rgba_parse(&rgba, (*C.gchar)(C.CString(color)))
-	C.gtk_widget_override_background_color(v.toWidget(), C.GTK_STATE_FLAG_NORMAL, &rgba)
-}

--- a/gtk/label.go
+++ b/gtk/label.go
@@ -131,10 +131,6 @@ func (v *Label) SetLineWrap(wrap bool) {
 	C.gtk_label_set_line_wrap(v.native(), gbool(wrap))
 }
 
-func (v *Label) SetFont(font string) {
-	C.gtk_widget_override_font(v.Widget.native(), C.pango_font_description_from_string(C.CString(font)))
-}
-
 // SetLineWrapMode is a wrapper around gtk_label_set_line_wrap_mode().
 func (v *Label) SetLineWrapMode(wrapMode pango.WrapMode) {
 	C.gtk_label_set_line_wrap_mode(v.native(), C.PangoWrapMode(wrapMode))


### PR DESCRIPTION
Current build process produce list of deprecated warnings:
```bash
[ddyakov@archlinux_dd2 gotk3]$ go build -v ./...
github.com/ddkv/gotk3/gtk
# github.com/ddkv/gotk3/gtk
cgo-gcc-prolog: In function ‘_cgo_9f28af190df4_Cfunc_gtk_container_get_focus_chain’:
cgo-gcc-prolog:2964:2: warning: ‘gtk_container_get_focus_chain’ is deprecated [-Wdeprecated-declarations]
In file included from /usr/include/gtk-3.0/gtk/gtkbin.h:33,
                 from /usr/include/gtk-3.0/gtk/gtkwindow.h:35,
                 from /usr/include/gtk-3.0/gtk/gtkdialog.h:32,
                 from /usr/include/gtk-3.0/gtk/gtkaboutdialog.h:30,
                 from /usr/include/gtk-3.0/gtk/gtk.h:31,
                 from gtk/gtk.go:48:
/usr/include/gtk-3.0/gtk/gtkcontainer.h:180:10: note: declared here
 gboolean gtk_container_get_focus_chain  (GtkContainer   *container,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cgo-gcc-prolog: In function ‘_cgo_9f28af190df4_Cfunc_gtk_container_set_focus_chain’:
cgo-gcc-prolog:3092:2: warning: ‘gtk_container_set_focus_chain’ is deprecated [-Wdeprecated-declarations]
In file included from /usr/include/gtk-3.0/gtk/gtkbin.h:33,
                 from /usr/include/gtk-3.0/gtk/gtkwindow.h:35,
                 from /usr/include/gtk-3.0/gtk/gtkdialog.h:32,
                 from /usr/include/gtk-3.0/gtk/gtkaboutdialog.h:30,
                 from /usr/include/gtk-3.0/gtk/gtk.h:31,
                 from gtk/gtk.go:48:
/usr/include/gtk-3.0/gtk/gtkcontainer.h:177:10: note: declared here
 void     gtk_container_set_focus_chain  (GtkContainer   *container,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cgo-gcc-prolog: In function ‘_cgo_9f28af190df4_Cfunc_gtk_css_provider_get_default’:
cgo-gcc-prolog:3145:2: warning: ‘gtk_css_provider_get_default’ is deprecated: Use 'gtk_css_provider_new' instead [-Wdeprecated-declarations]
In file included from /usr/include/gtk-3.0/gtk/gtk.h:82,
                 from gtk/gtk.go:48:
/usr/include/gtk-3.0/gtk/gtkcssprovider.h:116:18: note: declared here
 GtkCssProvider * gtk_css_provider_get_default (void);
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
# github.com/ddkv/gotk3/gtk
cgo-gcc-prolog: In function ‘_cgo_9f28af190df4_Cfunc_gtk_widget_override_background_color’:
cgo-gcc-prolog:317:2: warning: ‘gtk_widget_override_background_color’ is deprecated [-Wdeprecated-declarations]
In file included from /usr/include/gtk-3.0/gtk/gtkapplication.h:27,
                 from /usr/include/gtk-3.0/gtk/gtkwindow.h:33,
                 from /usr/include/gtk-3.0/gtk/gtkdialog.h:32,
                 from /usr/include/gtk-3.0/gtk/gtkaboutdialog.h:30,
                 from /usr/include/gtk-3.0/gtk/gtk.h:31,
                 from gtk/gtk_since_3_20.go:8:
/usr/include/gtk-3.0/gtk/gtkwidget.h:1148:14: note: declared here
 void         gtk_widget_override_background_color (GtkWidget     *widget,
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
# github.com/ddkv/gotk3/gtk
cgo-gcc-prolog: In function ‘_cgo_9f28af190df4_Cfunc_gtk_widget_override_font’:
cgo-gcc-prolog:638:2: warning: ‘gtk_widget_override_font’ is deprecated [-Wdeprecated-declarations]
In file included from /usr/include/gtk-3.0/gtk/gtkapplication.h:27,
                 from /usr/include/gtk-3.0/gtk/gtkwindow.h:33,
                 from /usr/include/gtk-3.0/gtk/gtkdialog.h:32,
                 from /usr/include/gtk-3.0/gtk/gtkaboutdialog.h:30,
                 from /usr/include/gtk-3.0/gtk/gtk.h:31,
                 from gtk/label.go:6:
/usr/include/gtk-3.0/gtk/gtkwidget.h:1153:14: note: declared here
 void         gtk_widget_override_font             (GtkWidget                  *widget,
              ^~~~~~~~~~~~~~~~~~~~~~~~
```