### PR TITLE
Ext2019 02

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -7623,6 +7623,14 @@ func (v *TextBuffer) CreateMark(mark_name string, where *TextIter, left_gravity 
 	return (*TextMark)(ret)
 }
 
+// GetMark() is a wrapper around gtk_text_buffer_get_mark().
+func (v *TextBuffer) GetMark(mark_name string) *TextMark {
+	cstr := C.CString(mark_name)
+	defer C.free(unsafe.Pointer(cstr))
+	ret := C.gtk_text_buffer_get_mark(v.native(), (*C.gchar)(cstr))
+	return (*TextMark)(ret)
+}
+
 /*
  * GtkToggleButton
  */

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -3348,6 +3348,13 @@ func (v *Entry) SetIconFromIconName(iconPos EntryIconPosition, name string) {
 		C.GtkEntryIconPosition(iconPos), (*C.gchar)(cstr))
 }
 
+// RemoveIcon() is a wrapper around gtk_entry_set_icon_from_icon_name()
+// with a nil pointer to the icon name.
+func (v *Entry) RemoveIcon(iconPos EntryIconPosition) {
+	C.gtk_entry_set_icon_from_icon_name(v.native(),
+		C.GtkEntryIconPosition(iconPos), nil)
+}
+
 // TODO(jrick) GIcon
 /*
 func (v *Entry) SetIconFromGIcon() {

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -8708,6 +8708,21 @@ func (v *TreeStore) Clear() {
 }
 
 /*
+ * TreeSortable
+ */
+
+// TreeSortable is a representation of GTK's GtkTreeSortable Interface.
+type TreeSortable interface {
+	SetSortColumnId(column int, order SortType)
+}
+
+// SetSortColumnId() is a wrapper around gtk_tree_sortable_set_sort_column_id().
+func (v *TreeStore) SetSortColumnId(column int, order SortType) {
+	sort := C.toGtkTreeSortable(unsafe.Pointer(v.Native()))
+	C.gtk_tree_sortable_set_sort_column_id(sort, C.gint(column), C.GtkSortType(order))
+}
+
+/*
  * GtkViewport
  */
 

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -7596,6 +7596,11 @@ func (v *TextBuffer) RemoveTag(tag *TextTag, start, end *TextIter) {
 	C.gtk_text_buffer_remove_tag(v.native(), tag.native(), (*C.GtkTextIter)(start), (*C.GtkTextIter)(end))
 }
 
+// RemoveAllTags() is a wrapper around gtk_text_buffer_remove_all_tags().
+func (v *TextBuffer) RemoveAllTags(start, end *TextIter) {
+	C.gtk_text_buffer_remove_all_tags(v.native(), (*C.GtkTextIter)(start), (*C.GtkTextIter)(end))
+}
+
 // SetModified() is a wrapper around gtk_text_buffer_set_modified().
 func (v *TextBuffer) SetModified(setting bool) {
 	C.gtk_text_buffer_set_modified(v.native(), gbool(setting))

--- a/gtk/widget.go
+++ b/gtk/widget.go
@@ -380,6 +380,16 @@ func (v *Widget) AddEvents(events int) {
 	C.gtk_widget_add_events(v.native(), C.gint(events))
 }
 
+// FreezeChildNotify is a wrapper around gtk_widget_freeze_child_notify().
+func (v *Widget) FreezeChildNotify() {
+	C.gtk_widget_freeze_child_notify(v.native())
+}
+
+// ThawChildNotify is a wrapper around gtk_widget_thaw_child_notify().
+func (v *Widget) ThawChildNotify() {
+	C.gtk_widget_thaw_child_notify(v.native())
+}
+
 // HasDefault is a wrapper around gtk_widget_has_default().
 func (v *Widget) HasDefault() bool {
 	c := C.gtk_widget_has_default(v.native())


### PR DESCRIPTION
I added some simple additional wrappers. The functions are:
* TextBuffer.GetMark around gtk_text_buffer_get_mark
* TextBuffer.RemoveAllTags around gtk_text_buffer_remove_all_tags
* Interface TreeSortable as a wrapper around GtkTreeSortable
* TreeStore.SetSortColumnId as an implementation of the interface TreeSortable and a wrapper around gtk_tree_sortable_set_sort_column_id
* Entry.RemoveIcon as a wrapper around gtk_entry_set_icon_from_icon_name. There is a wrapper around this function already. The existing wrapper does not allow to delete an icon (once placed). A nil pointer to a string allows such functionality in C. Since the existing function is probably used by someone I rather implemented a new function to provide the missing functionality.
* FreezeChildNotify as a wrapper around gtk_widget_freeze_child_notify and ThawChildNotify as a wrapper around gtk_widget_thaw_child_notify.