### PR TITLE
gtk_selection_data_set & gtk_drag_set_icon_pixbuf

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -6863,8 +6863,22 @@ func GetData(pointer uintptr) (data []byte) {
 	return byteData
 }
 
+//for "drag-data-get"
+func SetData(pointer uintptr, atom gdk.Atom, data []byte) {
+	c := (*C.GValue)(unsafe.Pointer(pointer))
+	p := (*C.GtkSelectionData)(unsafe.Pointer(c))
+	C.gtk_selection_data_set(p, C.GdkAtom(unsafe.Pointer(atom)), C.gint(8), (*C.guchar)(unsafe.Pointer(&data[0])), C.gint(len(data)))
+}
+
 func (v *SelectionData) free() {
 	C.gtk_selection_data_free(v.native())
+}
+
+//for "drag-begin" event
+func DragSetIconPixbuf(context *gdk.DragContext, pixbuf *gdk.Pixbuf, hot_x int, hot_y int) {
+	ctx := unsafe.Pointer(context.Native())
+	pix := unsafe.Pointer(pixbuf.Native())
+	C.gtk_drag_set_icon_pixbuf((*C.GdkDragContext)(ctx), (*C.GdkPixbuf)(pix), C.gint(hot_x), C.gint(hot_y))
 }
 
 /*


### PR DESCRIPTION
look there https://github.com/gotk3/gotk3/issues/327
and pull THIS first https://github.com/gotk3/gotk3/pull/328

usage example:
t_uri, _ := gtk.TargetEntryNew("text/uri-list", gtk.TARGET_OTHER_APP, 0)
evBox.DragSourceSet(gdk.GDK_BUTTON1_MASK, []gtk.TargetEntry{*t_uri}, gdk.ACTION_COPY)

evBox.Connect("drag-begin", func(g *gtk.EventBox, ctx *gdk.DragContext) {
fmt.Println("drag-begin")
pixbuf := .....
gtk.DragSetIconPixbuf(ctx, pixbuf, 0, 0)
})

evBox.Connect("drag-data-get", func(g *gtk.EventBox, ctx *gdk.DragContext, data_pointer uintptr, _ uint, _ uint) {
fmt.Println("drag-data-get")
cmd := "file://" + "/mnt/dm-1/testfile.txt" + "\n"
gtk.SetData(data_pointer, gdk.SELECTION_TYPE_STRING, []byte(cmd))
})