### PR TITLE
Add GetXID wrapper for gdk_x11_window_get_xid

### DIFF
--- a/cairo/cairo.go
+++ b/cairo/cairo.go
@@ -26,7 +26,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 func init() {

--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -28,7 +28,7 @@ import (
 	"strconv"
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 func init() {

--- a/gdk/gdk_deprecated_since_3_20.go
+++ b/gdk/gdk_deprecated_since_3_20.go
@@ -8,7 +8,7 @@ import (
 	"runtime"
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 // Grab() is a wrapper around gdk_device_grab().

--- a/gdk/gdk_pixbuf_format.go
+++ b/gdk/gdk_pixbuf_format.go
@@ -6,7 +6,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 type PixbufFormat struct {

--- a/gdk/gdk_since_3_22.go
+++ b/gdk/gdk_since_3_22.go
@@ -25,7 +25,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 /*

--- a/gdk/screen.go
+++ b/gdk/screen.go
@@ -6,7 +6,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 /*

--- a/gdk/window_x11.go
+++ b/gdk/window_x11.go
@@ -24,3 +24,9 @@ func (v *Window) GetDesktop() uint32 {
 func (v *Window) MoveToDesktop(d uint32) {
 	C.gdk_x11_window_move_to_desktop(v.native(), C.guint32(d))
 }
+
+// GetXID is a wrapper around gdk_x11_window_get_xid().
+// It only works on GDK versions compiled with X11 support - its return value can't be used if WorkspaceControlSupported returns false
+func (v *Window) GetXID() uint32 {
+        return uint32(C.gdk_x11_window_get_xid(v.native()))
+}

--- a/glib/glib_test.go
+++ b/glib/glib_test.go
@@ -4,8 +4,8 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/gotk3/gotk3/glib"
-	"github.com/gotk3/gotk3/gtk"
+	"github.com/patknight/gotk3/glib"
+	"github.com/patknight/gotk3/gtk"
 )
 
 func init() {

--- a/gtk/aboutdialog.go
+++ b/gtk/aboutdialog.go
@@ -6,8 +6,8 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/gdk"
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/gdk"
+	"github.com/patknight/gotk3/glib"
 )
 
 func init() {

--- a/gtk/accel.go
+++ b/gtk/accel.go
@@ -9,8 +9,8 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/gdk"
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/gdk"
+	"github.com/patknight/gotk3/glib"
 )
 
 // AccelFlags is a representation of GTK's GtkAccelFlags

--- a/gtk/actionable.go
+++ b/gtk/actionable.go
@@ -7,7 +7,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 func init() {

--- a/gtk/actionbar_since_3_12.go
+++ b/gtk/actionbar_since_3_12.go
@@ -31,7 +31,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 func init() {

--- a/gtk/app_chooser.go
+++ b/gtk/app_chooser.go
@@ -6,7 +6,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 func init() {

--- a/gtk/application.go
+++ b/gtk/application.go
@@ -10,7 +10,7 @@ import (
 	"runtime"
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 // ApplicationInhibitFlags is a representation of GTK's GtkApplicationInhibitFlags.

--- a/gtk/application_since_3_14.go
+++ b/gtk/application_since_3_14.go
@@ -10,7 +10,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 // PrefersAppMenu is a wrapper around gtk_application_prefers_app_menu().

--- a/gtk/application_window.go
+++ b/gtk/application_window.go
@@ -9,7 +9,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 /*

--- a/gtk/box_since_3_12.go
+++ b/gtk/box_since_3_12.go
@@ -31,7 +31,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 //gtk_box_bar_set_center_widget(GtkBox *box,GtkWidget *center_widget)

--- a/gtk/color_chooser.go
+++ b/gtk/color_chooser.go
@@ -6,8 +6,8 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/gdk"
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/gdk"
+	"github.com/patknight/gotk3/glib"
 )
 
 func init() {

--- a/gtk/combo_box.go
+++ b/gtk/combo_box.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 func init() {

--- a/gtk/fixed.go
+++ b/gtk/fixed.go
@@ -7,7 +7,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 func init() {

--- a/gtk/font_chooser.go
+++ b/gtk/font_chooser.go
@@ -6,7 +6,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 func init() {

--- a/gtk/gdk.go
+++ b/gtk/gdk.go
@@ -3,7 +3,7 @@ package gtk
 // #include <gtk/gtk.h>
 // #include "gtk.go.h"
 import "C"
-import "github.com/gotk3/gotk3/gdk"
+import "github.com/patknight/gotk3/gdk"
 
 func nativeGdkRectangle(rect gdk.Rectangle) *C.GdkRectangle {
 	// Note: Here we can't use rect.GdkRectangle because it would return

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -56,9 +56,9 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/gotk3/gotk3/cairo"
-	"github.com/gotk3/gotk3/gdk"
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/cairo"
+	"github.com/patknight/gotk3/gdk"
+	"github.com/patknight/gotk3/glib"
 )
 
 func init() {

--- a/gtk/gtk_deprecated_since_3_10.go
+++ b/gtk/gtk_deprecated_since_3_10.go
@@ -29,7 +29,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 // ButtonNewFromStock is a wrapper around gtk_button_new_from_stock().

--- a/gtk/gtk_deprecated_since_3_12.go
+++ b/gtk/gtk_deprecated_since_3_12.go
@@ -28,7 +28,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 /*

--- a/gtk/gtk_deprecated_since_3_14.go
+++ b/gtk/gtk_deprecated_since_3_14.go
@@ -9,8 +9,8 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/gdk"
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/gdk"
+	"github.com/patknight/gotk3/glib"
 )
 
 func init() {

--- a/gtk/gtk_deprecated_since_3_16.go
+++ b/gtk/gtk_deprecated_since_3_16.go
@@ -9,7 +9,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/gdk"
+	"github.com/patknight/gotk3/gdk"
 )
 
 // OverrideColor is a wrapper around gtk_widget_override_color().

--- a/gtk/gtk_deprecated_since_3_24.go
+++ b/gtk/gtk_deprecated_since_3_24.go
@@ -8,7 +8,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 // GetFocusChain is a wrapper around gtk_container_get_focus_chain().

--- a/gtk/gtk_export.go
+++ b/gtk/gtk_export.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 //export substring_match_equal_func

--- a/gtk/gtk_export_since_3_10.go
+++ b/gtk/gtk_export_since_3_10.go
@@ -7,7 +7,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 //export goListBoxFilterFuncs

--- a/gtk/gtk_since_3_10.go
+++ b/gtk/gtk_since_3_10.go
@@ -14,8 +14,8 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/gotk3/gotk3/gdk"
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/gdk"
+	"github.com/patknight/gotk3/glib"
 )
 
 func init() {

--- a/gtk/gtk_since_3_12.go
+++ b/gtk/gtk_since_3_12.go
@@ -11,7 +11,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 func init() {

--- a/gtk/gtk_since_3_16.go
+++ b/gtk/gtk_since_3_16.go
@@ -10,7 +10,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 func init() {

--- a/gtk/gtk_since_3_20.go
+++ b/gtk/gtk_since_3_20.go
@@ -11,7 +11,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 /*

--- a/gtk/gtk_test.go
+++ b/gtk/gtk_test.go
@@ -24,8 +24,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gotk3/gotk3/gdk"
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/gdk"
+	"github.com/patknight/gotk3/glib"
 )
 
 func init() {

--- a/gtk/icon_view.go
+++ b/gtk/icon_view.go
@@ -7,8 +7,8 @@ import (
 	"runtime"
 	"unsafe"
 
-	"github.com/gotk3/gotk3/gdk"
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/gdk"
+	"github.com/patknight/gotk3/glib"
 )
 
 /*

--- a/gtk/info_bar.go
+++ b/gtk/info_bar.go
@@ -6,7 +6,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 func init() {

--- a/gtk/label.go
+++ b/gtk/label.go
@@ -9,9 +9,9 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/pango"
+	"github.com/patknight/gotk3/pango"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 /*

--- a/gtk/level_bar.go
+++ b/gtk/level_bar.go
@@ -6,7 +6,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 func init() {

--- a/gtk/menu.go
+++ b/gtk/menu.go
@@ -9,7 +9,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 /*

--- a/gtk/menu_before_3_22.go
+++ b/gtk/menu_before_3_22.go
@@ -5,7 +5,7 @@ package gtk
 // #include <stdlib.h>
 // #include <gtk/gtk.h>
 import "C"
-import "github.com/gotk3/gotk3/gdk"
+import "github.com/patknight/gotk3/gdk"
 
 // PopupAtPointer() is a wrapper for gtk_menu_popup_at_pointer(), on older versions it uses PopupAtMouseCursor
 func (v *Menu) PopupAtPointer(_ *gdk.Event) {

--- a/gtk/menu_shell.go
+++ b/gtk/menu_shell.go
@@ -9,7 +9,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 /*

--- a/gtk/menu_since_3_22.go
+++ b/gtk/menu_since_3_22.go
@@ -8,7 +8,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/gdk"
+	"github.com/patknight/gotk3/gdk"
 )
 
 // PopupAtPointer() is a wrapper for gtk_menu_popup_at_pointer(), on older versions it uses PopupAtMouseCursor

--- a/gtk/popover_since_3_12.go
+++ b/gtk/popover_since_3_12.go
@@ -30,7 +30,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 func init() {

--- a/gtk/popover_since_3_18.go
+++ b/gtk/popover_since_3_18.go
@@ -9,7 +9,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 //void

--- a/gtk/print.go
+++ b/gtk/print.go
@@ -9,9 +9,9 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/gotk3/gotk3/cairo"
-	"github.com/gotk3/gotk3/glib"
-	"github.com/gotk3/gotk3/pango"
+	"github.com/patknight/gotk3/cairo"
+	"github.com/patknight/gotk3/glib"
+	"github.com/patknight/gotk3/pango"
 )
 
 func init() {

--- a/gtk/settings.go
+++ b/gtk/settings.go
@@ -6,7 +6,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 func init() {

--- a/gtk/shortcutswindow_since_3_22.go
+++ b/gtk/shortcutswindow_since_3_22.go
@@ -9,7 +9,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 func init() {

--- a/gtk/stack_since_3_12.go
+++ b/gtk/stack_since_3_12.go
@@ -13,7 +13,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 // GetChildByName is a wrapper around gtk_stack_get_child_by_name().

--- a/gtk/stackswitcher_since_3_10.go
+++ b/gtk/stackswitcher_since_3_10.go
@@ -13,7 +13,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 func init() {

--- a/gtk/style.go
+++ b/gtk/style.go
@@ -9,8 +9,8 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/gdk"
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/gdk"
+	"github.com/patknight/gotk3/glib"
 )
 
 type StyleProviderPriority int

--- a/gtk/text_iter.go
+++ b/gtk/text_iter.go
@@ -9,7 +9,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 /*

--- a/gtk/text_view.go
+++ b/gtk/text_view.go
@@ -8,8 +8,8 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/gdk"
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/gdk"
+	"github.com/patknight/gotk3/glib"
 )
 
 // TextWindowType is a representation of GTK's GtkTextWindowType.

--- a/gtk/tooltip.go
+++ b/gtk/tooltip.go
@@ -6,8 +6,8 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/gdk"
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/gdk"
+	"github.com/patknight/gotk3/glib"
 )
 
 /*

--- a/gtk/tree_view.go
+++ b/gtk/tree_view.go
@@ -10,8 +10,8 @@ import (
 	"runtime"
 	"unsafe"
 
-	"github.com/gotk3/gotk3/gdk"
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/gdk"
+	"github.com/patknight/gotk3/glib"
 )
 
 /*

--- a/gtk/tree_view_column.go
+++ b/gtk/tree_view_column.go
@@ -9,7 +9,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 /*

--- a/gtk/widget.go
+++ b/gtk/widget.go
@@ -10,8 +10,8 @@ import (
 	"errors"
 	"unsafe"
 
-	"github.com/gotk3/gotk3/gdk"
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/gdk"
+	"github.com/patknight/gotk3/glib"
 )
 
 /*

--- a/gtk/window.go
+++ b/gtk/window.go
@@ -10,8 +10,8 @@ import (
 	"errors"
 	"unsafe"
 
-	"github.com/gotk3/gotk3/gdk"
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/gdk"
+	"github.com/patknight/gotk3/glib"
 )
 
 /*

--- a/pango/pango-attributes.go
+++ b/pango/pango-attributes.go
@@ -24,7 +24,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 func init() {

--- a/pango/pango-context.go
+++ b/pango/pango-context.go
@@ -24,7 +24,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 func init() {

--- a/pango/pango-font.go
+++ b/pango/pango-font.go
@@ -27,7 +27,7 @@ import (
 	//	"github.com/andre-hub/gotk3/cairo"
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 func init() {

--- a/pango/pango-layout.go
+++ b/pango/pango-layout.go
@@ -24,7 +24,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/gotk3/gotk3/glib"
+	"github.com/patknight/gotk3/glib"
 )
 
 func init() {

--- a/pango/pangocairo.go
+++ b/pango/pangocairo.go
@@ -24,10 +24,10 @@ package pango
 // #include "pango.go.h"
 import "C"
 import (
-	//	"github.com/gotk3/gotk3/glib"
+	//	"github.com/patknight/gotk3/glib"
 	"unsafe"
 
-	"github.com/gotk3/gotk3/cairo"
+	"github.com/patknight/gotk3/cairo"
 )
 
 func init() {


### PR DESCRIPTION
Returns the X resource (window) belonging to a GdkWindow.

I needed this to allow libvlc to display on a gtk.DrawingArea. Tested in my app.