### PR TITLE
Add wrapper gdk.GetXID for gdk_x11_window_get_xid

### DIFF
--- a/gdk/window_x11.go
+++ b/gdk/window_x11.go
@@ -24,3 +24,9 @@ func (v *Window) GetDesktop() uint32 {
 func (v *Window) MoveToDesktop(d uint32) {
 	C.gdk_x11_window_move_to_desktop(v.native(), C.guint32(d))
 }
+
+// GetXID is a wrapper around gdk_x11_window_get_xid().
+// It only works on GDK versions compiled with X11 support - its return value can't be used if WorkspaceControlSupported returns false
+func (v *Window) GetXID() uint32 {
+        return uint32(C.gdk_x11_window_get_xid(v.native()))
+}


### PR DESCRIPTION
To embed movies in my app using libvlc, I need to get the XID for a gtk.DrawingArea to pass to libvlc.

Sequence is get the gdk window from a widget, then use this new function to get the underlying X window from the gdk window.

Tested with libvlc - movie played correctly.