### PR TITLE
Fix sign of passing parameter

### DIFF
--- a/pango/fontconfig.go.h
+++ b/pango/fontconfig.go.h
@@ -1,7 +1,7 @@
 
 #include <fontconfig/fontconfig.h>
 
-static int addFont(char* font) {
+static int addFont(unsigned char* font) {
     FcBool fontAddStatus = FcConfigAppFontAddFile(FcConfigGetCurrent(), font);
     return fontAddStatus;
 }

--- a/pango/pango-font.go
+++ b/pango/pango-font.go
@@ -39,7 +39,7 @@ func init() {
 	glib.RegisterGValueMarshalers(tm)
 }
 
-// AddFont add the font to the configuration.
+// AddFont adds the font to the configuration.
 func AddFont(fontPath string) {
 	path := (*C.uchar)(unsafe.Pointer(C.CString(fontPath)))
 	C.addFont(path)

--- a/pango/pango-font.go
+++ b/pango/pango-font.go
@@ -39,8 +39,9 @@ func init() {
 	glib.RegisterGValueMarshalers(tm)
 }
 
+// AddFont add the font to the configuration.
 func AddFont(fontPath string) {
-	C.addFont(C.CString(fontPath))
+	C.addFont(C.UChar(C.CString(fontPath)))
 }
 
 // FontDescription is a representation of PangoFontDescription.

--- a/pango/pango-font.go
+++ b/pango/pango-font.go
@@ -41,7 +41,8 @@ func init() {
 
 // AddFont add the font to the configuration.
 func AddFont(fontPath string) {
-	C.addFont(C.UChar(C.CString(fontPath)))
+	path := (*C.uchar)(unsafe.Pointer(C.CString(fontPath)))
+	C.addFont(path)
 }
 
 // FontDescription is a representation of PangoFontDescription.


### PR DESCRIPTION
I was reported: 

```
../gotk3/gotk3/pango/fontconfig.go.h:5:73: warning: passing 'char *' to parameter of type 'const
 FcChar8 *' (aka 'const unsigned char *') converts between pointers to integer types with different sign
 [-Wpointer-sign]
```

as 'FcConfigAppFontAddFile' takes an unsigned char: https://gitlab.freedesktop.org/fontconfig/fontconfig/blob/master/fontconfig/fontconfig.h#L449

This hopefully fixes it. 