### PR TITLE
Add support for GtkTreeRowRef

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -8642,6 +8642,64 @@ func (v *TreeSelection) UnselectAll() {
 }
 
 /*
+ * GtkTreeRowReference
+ */
+
+// TreeRowReference is a representation of GTK's GtkTreeRowReference.
+type TreeRowReference struct {
+	GtkTreeRowReference *C.GtkTreeRowReference
+}
+
+func (v *TreeRowReference) native() *C.GtkTreeRowReference {
+	if v == nil {
+		return nil
+	}
+	return v.GtkTreeRowReference
+}
+
+func (v *TreeRowReference) free() {
+	C.gtk_tree_row_reference_free(v.native())
+}
+
+// TreeRowReferenceNew is a wrapper around gtk_tree_row_reference_new().
+func TreeRowReferenceNew(model *TreeModel, path *TreePath) (*TreeRowReference, error) {
+	c := C.gtk_tree_row_reference_new(model.native(), path.native())
+	if c == nil {
+		return nil, nilPtrErr
+	}
+	r := &TreeRowReference{c}
+	runtime.SetFinalizer(r, (*TreeRowReference).free)
+	return r, nil
+}
+
+// GetPath is a wrapper around gtk_tree_row_reference_get_path.
+func (v *TreeRowReference) GetPath() *TreePath {
+	c := C.gtk_tree_row_reference_get_path(v.native())
+	if c == nil {
+		return nil
+	}
+	t := &TreePath{c}
+	runtime.SetFinalizer(t, (*TreePath).free)
+	return t
+}
+
+// GetModel is a wrapper around gtk_tree_row_reference_get_path.
+func (v *TreeRowReference) GetModel() ITreeModel {
+	c := C.gtk_tree_row_reference_get_model(v.native())
+	if c == nil {
+		return nil
+	}
+	m := wrapTreeModel(glib.Take(unsafe.Pointer(c)))
+	return m
+}
+
+// Valid is a wrapper around gtk_tree_row_reference_valid.
+func (v *TreeRowReference) Valid() bool {
+	c := C.gtk_tree_row_reference_valid(v.native())
+	return gobool(c)
+}
+
+/*
  * GtkTreeStore
  */
 

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -8453,6 +8453,14 @@ func (v *TreeModelFilter) SetVisibleColumn(column int) {
 	C.gtk_tree_model_filter_set_visible_column(v.native(), C.gint(column))
 }
 
+// ConvertIterToChildIter is a wrapper around gtk_tree_model_filter_convert_child_iter_to_iter().
+func (v *TreeModelFilter) ConvertIterToChildIter(filterIter *TreeIter) *TreeIter {
+	var iter C.GtkTreeIter
+	C.gtk_tree_model_filter_convert_iter_to_child_iter(v.native(), &iter, filterIter.native())
+	t := &TreeIter{iter}
+	return t
+}
+
 /*
  * GtkTreePath
  */

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -8453,14 +8453,6 @@ func (v *TreeModelFilter) SetVisibleColumn(column int) {
 	C.gtk_tree_model_filter_set_visible_column(v.native(), C.gint(column))
 }
 
-// ConvertIterToChildIter is a wrapper around gtk_tree_model_filter_convert_child_iter_to_iter().
-func (v *TreeModelFilter) ConvertIterToChildIter(filterIter *TreeIter) *TreeIter {
-	var iter C.GtkTreeIter
-	C.gtk_tree_model_filter_convert_iter_to_child_iter(v.native(), &iter, filterIter.native())
-	t := &TreeIter{iter}
-	return t
-}
-
 /*
  * GtkTreePath
  */


### PR DESCRIPTION
Tested in a small app by deleting multiple rows from a ListStore after selecting them in a TreeView. TreeRowRef is the standard pattern for this, as TreePaths change meaning if rows before them are deleted.