### PR TITLE
Additional support for TreeModelFilter

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -8534,6 +8534,8 @@ func (v *TreeModelFilter) Refilter() {
 	C.gtk_tree_model_filter_refilter(v.native())
 }
 
+// TreeModelFilterVisibleFunc defines the function prototype for the filter visibility function (f arg)
+// to TreeModelFilter.SetVisibleFunc.
 type TreeModelFilterVisibleFunc func(model *TreeModelFilter, iter *TreeIter, userData interface{}) bool
 
 type treeModelFilterVisibleFuncData struct {

--- a/gtk/gtk.go.h
+++ b/gtk/gtk.go.h
@@ -921,3 +921,9 @@ static inline void _gtk_print_run_page_setup_dialog_async(GtkWindow *parent, Gtk
 	gtk_print_run_page_setup_dialog_async(parent, setup, settings,
 		(GtkPageSetupDoneFunc)(goPageSetupDone), data);
 }
+
+extern gboolean goTreeModelFilterFuncs (GtkTreeModel *model, GtkTreeIter *iter, gpointer data);
+
+static inline void _gtk_tree_model_filter_set_visible_func(GtkTreeModelFilter *filter, gpointer user_data) {
+    gtk_tree_model_filter_set_visible_func(filter, (GtkTreeModelFilterVisibleFunc)(goTreeModelFilterFuncs), user_data, NULL);
+}

--- a/gtk/gtk_export.go
+++ b/gtk/gtk_export.go
@@ -102,3 +102,18 @@ func goPrintSettings(key *C.gchar,
 	r.fn(C.GoString((*C.char)(key)), C.GoString((*C.char)(value)), r.userData)
 
 }
+
+//export goTreeModelFilterFuncs
+func goTreeModelFilterFuncs(filter *C.GtkTreeModelFilter, iter *C.GtkTreeIter, data C.gpointer) C.gboolean {
+	id := int(uintptr(data))
+
+	treeModelVisibleFilterFuncRegistry.Lock()
+	r := treeModelVisibleFilterFuncRegistry.m[id]
+	treeModelVisibleFilterFuncRegistry.Unlock()
+
+	goIter := &TreeIter{(C.GtkTreeIter)(*iter)}
+	return gbool(r.fn(
+		wrapTreeModelFilter(glib.Take(unsafe.Pointer(filter))),
+		goIter,
+		r.userData))
+}


### PR DESCRIPTION
* Add TreeModelFilter.ConvertPathToChildPath - wrapper for gtk_tree_model_filter_convert_path_to_child_path

* Add support for TreeModelFilter.SetVisibleFunc - wrappers for gtk_tree_model_filter_set_visible_func and  gtk_tree_model_filter_refilter + implementation of a filter func registry modeled on existing registries.