### PR TITLE
Fix for issue #358 - Can't set an iconview model to nil

### DIFF
--- a/gtk/combo_box.go
+++ b/gtk/combo_box.go
@@ -147,7 +147,11 @@ func (v *ComboBox) GetModel() (*TreeModel, error) {
 
 // SetModel is a wrapper around gtk_combo_box_set_model().
 func (v *ComboBox) SetModel(model ITreeModel) {
-	C.gtk_combo_box_set_model(v.native(), model.toTreeModel())
+	var mptr *C.GtkTreeModel
+	if model != nil {
+		mptr = model.toTreeModel()
+	}
+	C.gtk_combo_box_set_model(v.native(), mptr)
 }
 
 func (v *ComboBox) Popup() {

--- a/gtk/icon_view.go
+++ b/gtk/icon_view.go
@@ -61,7 +61,11 @@ func IconViewNewWithModel(model ITreeModel) (*IconView, error) {
 
 // SetModel is a wrapper around gtk_icon_view_set_model().
 func (v *IconView) SetModel(model ITreeModel) {
-	C.gtk_icon_view_set_model(v.native(), model.toTreeModel())
+	var mptr *C.GtkTreeModel
+	if model != nil {
+		mptr = model.toTreeModel()
+	}
+	C.gtk_icon_view_set_model(v.native(), mptr)
 }
 
 // GetModel is a wrapper around gtk_icon_view_get_model().

--- a/gtk/tree_view.go
+++ b/gtk/tree_view.go
@@ -71,11 +71,11 @@ func (v *TreeView) GetModel() (*TreeModel, error) {
 
 // SetModel is a wrapper around gtk_tree_view_set_model().
 func (v *TreeView) SetModel(model ITreeModel) {
-	if model == nil {
-		C.gtk_tree_view_set_model(v.native(), nil)
-	} else {
-		C.gtk_tree_view_set_model(v.native(), model.toTreeModel())
+	var mptr *C.GtkTreeModel
+	if model != nil {
+		mptr = model.toTreeModel()
 	}
+	C.gtk_tree_view_set_model(v.native(), mptr)
 }
 
 // GetSelection is a wrapper around gtk_tree_view_get_selection().


### PR DESCRIPTION
Fixes issue #358 by checking the model parameter is not nil before trying to call its toTreeModel(). Fix for ComboBox and TreeView as well as IconView. TreeView had an older fix coded a different way (involving two calls to gtk_tree_view_set_model.) I modified that function so that all three SetModel implementations are consistent. I didn't modify any other places where toTreeModel() is called because those were all contexts were nil/NULL is not allowed, so the panic is OK.