### PR TITLE
Issue361 marshal object

### DIFF
--- a/glib/glib.go
+++ b/glib/glib.go
@@ -427,6 +427,7 @@ func (v *Object) goValue() (interface{}, error) {
 		return nil, err
 	}
 
+	// The marshalers expect Values, not Objects
 	val, err := ValueInit(objType)
 	if err != nil {
 		return nil, err

--- a/glib/glib.go
+++ b/glib/glib.go
@@ -201,6 +201,23 @@ func goMarshal(closure *C.GClosure, retValue *C.GValue,
 				"no suitable Go value for arg %d: %v\n", i, err)
 			return
 		}
+		// Parameters that are descendants of GObject come wrapped in another GObject.
+		// For C applications, the default marshaller (g_cclosure_marshal_VOID__VOID in
+		// gmarshal.c in the GTK glib library) 'peeks' into the enclosing object and
+		// passes the wrapped object to the handler. Use the *Object.goValue function
+		// to emulate that for Go signal handlers.
+		switch objVal := val.(type) {
+		case *Object:
+			innerVal, err := objVal.goValue()
+			if err != nil {
+				// print warning and leave val unchanged to preserve old
+				// behavior
+				fmt.Fprintf(os.Stderr,
+					"warning: no suitable Go value from object for arg %d: %v\n", i, err)
+			} else {
+				val = innerVal
+			}
+		}
 		rv := reflect.ValueOf(val)
 		args = append(args, rv.Convert(cc.rf.Type().In(i)))
 	}
@@ -398,6 +415,25 @@ func (v *Object) native() *C.GObject {
 	}
 	p := unsafe.Pointer(v.GObject)
 	return C.toGObject(p)
+}
+
+// goValue converts a *Object to a Go type (e.g. *Object => *gtk.Entry).
+// It is used in goMarshal to convert generic GObject parameters to
+// signal handlers to the actual types expected by the signal handler.
+func (v *Object) goValue() (interface{}, error) {
+	objType := Type(C._g_type_from_instance(C.gpointer(v.native())))
+	f, err := gValueMarshalers.lookupType(objType)
+	if err != nil {
+		return nil, err
+	}
+
+	val, err := ValueInit(objType)
+	if err != nil {
+		return nil, err
+	}
+	val.SetInstance(uintptr(unsafe.Pointer(v.GObject)))
+	rv, err := f(uintptr(unsafe.Pointer(val.native())))
+	return rv, err
 }
 
 // Take wraps a unsafe.Pointer as a glib.Object, taking ownership of it.
@@ -1106,6 +1142,13 @@ func (m marshalMap) lookup(v *Value) (GValueMarshaler, error) {
 		return f, nil
 	}
 	if f, ok := m[fundamental]; ok {
+		return f, nil
+	}
+	return nil, errors.New("missing marshaler for type")
+}
+
+func (m marshalMap) lookupType(t Type) (GValueMarshaler, error) {
+	if f, ok := m[Type(t)]; ok {
 		return f, nil
 	}
 	return nil, errors.New("missing marshaler for type")


### PR DESCRIPTION
This is the fix for issue #361. The root cause was that signal parameters representing objects are
passed to the marshaler that's going to actually call the signal handler wrap the object in a generic one.
In C applications, the marshaler `g_cclosure_marshal_VOID__VOID` unwraps the object before calling the signal handler. Added code to glib.goMarshal to do this unwrapping.

Here's a small program to show the fix. Without the fix, the program panics when you hit the enter key in the Entry (can't convert *Object to *Entry.) With the fix, everything works, and the contents of the Entry are printed.

```go
package main

import (
	"fmt"
	"os"

	"github.com/gotk3/gotk3/gtk"
)

func fatal(format string, args ...interface{}) {
	fmt.Printf(format, args...)
	os.Exit(1)
}

func main() {
	gtk.Init(nil)

	w, err := gtk.WindowNew(gtk.WINDOW_TOPLEVEL)
	if err != nil {
		fatal("WindowNew: %v\n", err)
	}
	w.Connect("destroy", destroyAction)

	box, err := gtk.BoxNew(gtk.ORIENTATION_VERTICAL, 2)
	if err != nil {
		fatal("BoxNew: %v\n", err)
	}

	entry, err := gtk.EntryNew()
	if err != nil {
		fatal("EntryNew: %v\n", err)
	}
	fmt.Println("entry connect starts")
	entry.Connect("activate", entryAction)
	fmt.Println("entry connect done")

	button, err := gtk.ButtonNewWithLabel("click me")
	if err != nil {
		fatal("ButtonNew: %v\n", err)
	}
	fmt.Println("button connect starts")
	button.Connect("clicked", buttonAction)
	fmt.Println("button connect done")

	box.PackStart(entry, true, true, 0)
	box.PackStart(button, false, false, 0)
	w.Add(box)

	w.ShowAll()
	gtk.Main()
}

func entryAction(e *gtk.Entry) {
	t, err := e.GetText()
	if err != nil {
		fatal("GetText: %v\n", err)
	}
	fmt.Printf("entry text: %s\n", t)
}

func buttonAction(b *gtk.Button) {
	fmt.Println("clicked")
}

func destroyAction(w *gtk.Window) {
	fmt.Println("destroyed")
	gtk.MainQuit()
}
```

