### PR TITLE
InsertWithTag() is a wrapper around gtk_text_buffer_insert_with_tags() that supports only one tag

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -7658,6 +7658,14 @@ func (v *TextBuffer) InsertAtCursor(text string) {
 	C.gtk_text_buffer_insert_at_cursor(v.native(), (*C.gchar)(cstr), C.gint(len(text)))
 }
 
+// InsertWithTag() is a wrapper around gtk_text_buffer_insert_with_tags() that supports only one tag
+// as cgo does not support functions with variable-argument lists (see https://github.com/golang/go/issues/975)
+func (v *TextBuffer) InsertWithTag(iter *TextIter, text string, tag *TextTag) {
+	cstr := C.CString(text)
+	defer C.free(unsafe.Pointer(cstr))
+	C._gtk_text_buffer_insert_with_tag(v.native(), (*C.GtkTextIter)(iter), (*C.gchar)(cstr), C.gint(len(text)), tag.native())
+}
+
 // RemoveTag() is a wrapper around gtk_text_buffer_remove_tag().
 func (v *TextBuffer) RemoveTag(tag *TextTag, start, end *TextIter) {
 	C.gtk_text_buffer_remove_tag(v.native(), tag.native(), (*C.GtkTextIter)(start), (*C.GtkTextIter)(end))

--- a/gtk/gtk.go.h
+++ b/gtk/gtk.go.h
@@ -927,3 +927,7 @@ extern gboolean goTreeModelFilterFuncs (GtkTreeModel *model, GtkTreeIter *iter, 
 static inline void _gtk_tree_model_filter_set_visible_func(GtkTreeModelFilter *filter, gpointer user_data) {
     gtk_tree_model_filter_set_visible_func(filter, (GtkTreeModelFilterVisibleFunc)(goTreeModelFilterFuncs), user_data, NULL);
 }
+
+static inline void _gtk_text_buffer_insert_with_tag(GtkTextBuffer* buffer, GtkTextIter* iter, const gchar* text, gint len, GtkTextTag* tag) {
+	gtk_text_buffer_insert_with_tags(buffer, iter, text, len, tag, NULL);
+}


### PR DESCRIPTION
Please could you merge this wrapper. As cgo does not support functions with variable-argument lists (see https://github.com/golang/go/issues/975), I have created a wrapper with only one tag as I found it useful for my needs (same approach has been applied in go-gtk).