### PR TITLE
InsertWithTagByName() is a wrapper around gtk_text_buffer_insert_with _tags_by_name() that supports only one tag

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -7666,6 +7666,16 @@ func (v *TextBuffer) InsertWithTag(iter *TextIter, text string, tag *TextTag) {
 	C._gtk_text_buffer_insert_with_tag(v.native(), (*C.GtkTextIter)(iter), (*C.gchar)(cstr), C.gint(len(text)), tag.native())
 }
 
+// InsertWithTagByName() is a wrapper around gtk_text_buffer_insert_with_tags_by_name() that supports only one tag
+// as cgo does not support functions with variable-argument lists (see https://github.com/golang/go/issues/975)
+func (v *TextBuffer) InsertWithTagByName(iter *TextIter, text string, tagName string) {
+	cstr := C.CString(text)
+	defer C.free(unsafe.Pointer(cstr))
+	ctag := C.CString(tagName)
+	defer C.free(unsafe.Pointer(ctag))
+	C._gtk_text_buffer_insert_with_tag_by_name(v.native(), (*C.GtkTextIter)(iter), (*C.gchar)(cstr), C.gint(len(text)), (*C.gchar)(ctag))
+}
+
 // RemoveTag() is a wrapper around gtk_text_buffer_remove_tag().
 func (v *TextBuffer) RemoveTag(tag *TextTag, start, end *TextIter) {
 	C.gtk_text_buffer_remove_tag(v.native(), tag.native(), (*C.GtkTextIter)(start), (*C.GtkTextIter)(end))

--- a/gtk/gtk.go.h
+++ b/gtk/gtk.go.h
@@ -928,6 +928,10 @@ static inline void _gtk_tree_model_filter_set_visible_func(GtkTreeModelFilter *f
     gtk_tree_model_filter_set_visible_func(filter, (GtkTreeModelFilterVisibleFunc)(goTreeModelFilterFuncs), user_data, NULL);
 }
 
+static inline void _gtk_text_buffer_insert_with_tag_by_name(GtkTextBuffer* buffer, GtkTextIter* iter, const gchar* text, gint len, const gchar* first_tag_name) {
+	gtk_text_buffer_insert_with_tags_by_name(buffer, iter, text, len, first_tag_name, NULL);
+}
+
 static inline void _gtk_text_buffer_insert_with_tag(GtkTextBuffer* buffer, GtkTextIter* iter, const gchar* text, gint len, GtkTextTag* tag) {
 	gtk_text_buffer_insert_with_tags(buffer, iter, text, len, tag, NULL);
 }


### PR DESCRIPTION
Please could you merge this wrapper. As cgo does not support functions with variable-argument lists (see golang/go#975), I have created a wrapper with only one tag as I found it useful for my needs.