### PR TITLE
Wrap gtk_tree_sortable_set_sort_func() for gtk.ListStore

### DIFF
--- a/gtk/gtk.go.h
+++ b/gtk/gtk.go.h
@@ -935,3 +935,9 @@ static inline void _gtk_text_buffer_insert_with_tag_by_name(GtkTextBuffer* buffe
 static inline void _gtk_text_buffer_insert_with_tag(GtkTextBuffer* buffer, GtkTextIter* iter, const gchar* text, gint len, GtkTextTag* tag) {
 	gtk_text_buffer_insert_with_tags(buffer, iter, text, len, tag, NULL);
 }
+
+extern gint goTreeSortableSortFuncs(GtkTreeModel *model, GtkTreeIter *a, GtkTreeIter *b, gpointer data);
+
+static inline void _gtk_tree_sortable_set_sort_func(GtkTreeSortable *sortable, gint sort_column_id, gpointer user_data) {
+    gtk_tree_sortable_set_sort_func(sortable, sort_column_id, (GtkTreeIterCompareFunc)(goTreeSortableSortFuncs), user_data, NULL);
+}

--- a/gtk/gtk_export.go
+++ b/gtk/gtk_export.go
@@ -117,3 +117,17 @@ func goTreeModelFilterFuncs(filter *C.GtkTreeModelFilter, iter *C.GtkTreeIter, d
 		goIter,
 		r.userData))
 }
+
+//export goTreeSortableSortFuncs
+func goTreeSortableSortFuncs(model *C.GtkTreeModel, a, b *C.GtkTreeIter, data C.gpointer) C.gint {
+	id := int(uintptr(data))
+
+	treeStoreSortFuncRegistry.Lock()
+	r := treeStoreSortFuncRegistry.m[id]
+	treeStoreSortFuncRegistry.Unlock()
+
+	goIterA := &TreeIter{(C.GtkTreeIter)(*a)}
+	goIterB := &TreeIter{(C.GtkTreeIter)(*b)}
+
+	return C.gint(r.fn(wrapTreeModel(glib.Take(unsafe.Pointer(model))), goIterA, goIterB, r.userData))
+}


### PR DESCRIPTION
I need to keep a list of metadata about files sorted in the same order as in a gtk.ListStore, using filename as the sort key. The filenames contain special characters (e.g. [, {, etc.) The GTK sort algorithm uses
a collating sequence for en_US that isn't documented and doesn't match what I can get from using
golang.org/x/text collation. 

Even if I could emulate GTK sort, they could change the algorithm in a later version, so I want to use my collation sequence for both my metadata and the ListStore. I've wrapped gtk_tree_sortable_set_sort_func in a generic way for *C.GtkTreeSortable and then call the generic function from (*gtk.ListStore).SetSortFunc. This should make it easy for others to wrap SetSortFunc for other types implementing the GtkTreeSortable interface.