### PR TITLE
Use gtk.IWindow instead of *gtk.Window

### DIFF
--- a/gtk/app_chooser.go
+++ b/gtk/app_chooser.go
@@ -329,12 +329,12 @@ func wrapAppChooserDialog(obj *glib.Object) *AppChooserDialog {
 
 // TODO: Uncomment when gio builds successfully
 // AppChooserDialogNew() is a wrapper around gtk_app_chooser_dialog_new().
-// func AppChooserDialogNew(parent *Window, flags DialogFlags, file *gio.File) (*AppChooserDialog, error) {
+// func AppChooserDialogNew(parent IWindow, flags DialogFlags, file *gio.File) (*AppChooserDialog, error) {
 // 	var gfile *C.GFile
 // 	if file != nil {
 // 		gfile = (*C.GFile)(unsafe.Pointer(file.Native()))
 // 	}
-// 	c := C.gtk_app_chooser_dialog_new(parent.native(), C.GtkDialogFlags(flags), gfile)
+// 	c := C.gtk_app_chooser_dialog_new(parent.toWindow(), C.GtkDialogFlags(flags), gfile)
 // 	if c == nil {
 // 		return nil, nilPtrErr
 // 	}
@@ -342,10 +342,10 @@ func wrapAppChooserDialog(obj *glib.Object) *AppChooserDialog {
 // }
 
 // AppChooserDialogNewForContentType() is a wrapper around gtk_app_chooser_dialog_new_for_content_type().
-func AppChooserDialogNewForContentType(parent *Window, flags DialogFlags, content_type string) (*AppChooserDialog, error) {
+func AppChooserDialogNewForContentType(parent IWindow, flags DialogFlags, content_type string) (*AppChooserDialog, error) {
 	cstr := C.CString(content_type)
 	defer C.free(unsafe.Pointer(cstr))
-	c := C.gtk_app_chooser_dialog_new_for_content_type(parent.native(), C.GtkDialogFlags(flags), (*C.gchar)(cstr))
+	c := C.gtk_app_chooser_dialog_new_for_content_type(parent.toWindow(), C.GtkDialogFlags(flags), (*C.gchar)(cstr))
 	if c == nil {
 		return nil, nilPtrErr
 	}

--- a/gtk/application.go
+++ b/gtk/application.go
@@ -65,13 +65,13 @@ func ApplicationNew(appId string, flags glib.ApplicationFlags) (*Application, er
 }
 
 // AddWindow is a wrapper around gtk_application_add_window().
-func (v *Application) AddWindow(w *Window) {
-	C.gtk_application_add_window(v.native(), w.native())
+func (v *Application) AddWindow(w IWindow) {
+	C.gtk_application_add_window(v.native(), w.toWindow())
 }
 
 // RemoveWindow is a wrapper around gtk_application_remove_window().
-func (v *Application) RemoveWindow(w *Window) {
-	C.gtk_application_remove_window(v.native(), w.native())
+func (v *Application) RemoveWindow(w IWindow) {
+	C.gtk_application_remove_window(v.native(), w.toWindow())
 }
 
 // GetWindowByID is a wrapper around gtk_application_get_window_by_id().
@@ -133,11 +133,11 @@ func (v *Application) IsInhibited(flags ApplicationInhibitFlags) bool {
 }
 
 // Inhibited is a wrapper around gtk_application_inhibit().
-func (v *Application) Inhibited(w *Window, flags ApplicationInhibitFlags, reason string) uint {
+func (v *Application) Inhibited(w IWindow, flags ApplicationInhibitFlags, reason string) uint {
 	cstr1 := (*C.gchar)(C.CString(reason))
 	defer C.free(unsafe.Pointer(cstr1))
 
-	return uint(C.gtk_application_inhibit(v.native(), w.native(), C.GtkApplicationInhibitFlags(flags), cstr1))
+	return uint(C.gtk_application_inhibit(v.native(), w.toWindow(), C.GtkApplicationInhibitFlags(flags), cstr1))
 }
 
 // void 	gtk_application_add_accelerator () // deprecated and uses a gvariant paramater

--- a/gtk/color_chooser.go
+++ b/gtk/color_chooser.go
@@ -137,10 +137,10 @@ func wrapColorChooserDialog(obj *glib.Object) *ColorChooserDialog {
 }
 
 // ColorChooserDialogNew() is a wrapper around gtk_color_chooser_dialog_new().
-func ColorChooserDialogNew(title string, parent *Window) (*ColorChooserDialog, error) {
+func ColorChooserDialogNew(title string, parent IWindow) (*ColorChooserDialog, error) {
 	cstr := C.CString(title)
 	defer C.free(unsafe.Pointer(cstr))
-	c := C.gtk_color_chooser_dialog_new((*C.gchar)(cstr), parent.native())
+	c := C.gtk_color_chooser_dialog_new((*C.gchar)(cstr), parent.toWindow())
 	if c == nil {
 		return nil, nilPtrErr
 	}

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -4049,7 +4049,7 @@ func wrapFileChooserDialog(obj *glib.Object) *FileChooserDialog {
 // FileChooserDialogNewWith1Button is a wrapper around gtk_file_chooser_dialog_new() with one button.
 func FileChooserDialogNewWith1Button(
 	title string,
-	parent *Window,
+	parent IWindow,
 	action FileChooserAction,
 	first_button_text string,
 	first_button_id ResponseType) (*FileChooserDialog, error) {
@@ -4058,7 +4058,7 @@ func FileChooserDialogNewWith1Button(
 	c_first_button_text := C.CString(first_button_text)
 	defer C.free(unsafe.Pointer(c_first_button_text))
 	c := C.gtk_file_chooser_dialog_new_1(
-		(*C.gchar)(c_title), parent.native(), C.GtkFileChooserAction(action),
+		(*C.gchar)(c_title), parent.toWindow(), C.GtkFileChooserAction(action),
 		(*C.gchar)(c_first_button_text), C.int(first_button_id))
 	if c == nil {
 		return nil, nilPtrErr
@@ -4070,7 +4070,7 @@ func FileChooserDialogNewWith1Button(
 // FileChooserDialogNewWith2Buttons is a wrapper around gtk_file_chooser_dialog_new() with two buttons.
 func FileChooserDialogNewWith2Buttons(
 	title string,
-	parent *Window,
+	parent IWindow,
 	action FileChooserAction,
 	first_button_text string,
 	first_button_id ResponseType,
@@ -4083,7 +4083,7 @@ func FileChooserDialogNewWith2Buttons(
 	c_second_button_text := C.CString(second_button_text)
 	defer C.free(unsafe.Pointer(c_second_button_text))
 	c := C.gtk_file_chooser_dialog_new_2(
-		(*C.gchar)(c_title), parent.native(), C.GtkFileChooserAction(action),
+		(*C.gchar)(c_title), parent.toWindow(), C.GtkFileChooserAction(action),
 		(*C.gchar)(c_first_button_text), C.int(first_button_id),
 		(*C.gchar)(c_second_button_text), C.int(second_button_id))
 	if c == nil {

--- a/gtk/gtk_since_3_20.go
+++ b/gtk/gtk_since_3_20.go
@@ -133,7 +133,7 @@ func wrapFileChooserNativeDialog(obj *glib.Object) *FileChooserNativeDialog {
 // FileChooserNativeDialogNew is a wrapper around gtk_file_chooser_native_new().
 func FileChooserNativeDialogNew(
 	title string,
-	parent *Window,
+	parent IWindow,
 	action FileChooserAction,
 	accept_label string,
 	cancel_label string) (*FileChooserNativeDialog, error) {
@@ -144,7 +144,7 @@ func FileChooserNativeDialogNew(
 	c_cancel_label := C.CString(cancel_label)
 	defer C.free(unsafe.Pointer(c_cancel_label))
 	c := C.gtk_file_chooser_native_new(
-		(*C.gchar)(c_title), parent.native(), C.GtkFileChooserAction(action),
+		(*C.gchar)(c_title), parent.toWindow(), C.GtkFileChooserAction(action),
 		(*C.gchar)(c_accept_label), (*C.gchar)(c_cancel_label))
 	if c == nil {
 		return nil, nilPtrErr
@@ -156,13 +156,13 @@ func FileChooserNativeDialogNew(
 /*
  * FileChooserNative
  */
-func OpenFileChooserNative(title string, parent_window *Window) *string {
+func OpenFileChooserNative(title string, parent_window IWindow) *string {
 	c_title := C.CString(title)
 
 	var native *C.GtkFileChooserNative
 
 	native = C.gtk_file_chooser_native_new((*C.gchar)(c_title),
-		parent_window.native(),
+		parent_window.toWindow(),
 		C.GtkFileChooserAction(FILE_CHOOSER_ACTION_OPEN),
 		(*C.gchar)(C.CString("_Open")),
 		(*C.gchar)(C.CString("_Cancel")))

--- a/gtk/print.go
+++ b/gtk/print.go
@@ -870,9 +870,9 @@ func (po *PrintOperation) SetCustomTabLabel(label string) {
 }
 
 // Run() is a wrapper around gtk_print_operation_run().
-func (po *PrintOperation) Run(action PrintOperationAction, parent *Window) (PrintOperationResult, error) {
+func (po *PrintOperation) Run(action PrintOperationAction, parent IWindow) (PrintOperationResult, error) {
 	var err *C.GError = nil
-	c := C.gtk_print_operation_run(po.native(), C.GtkPrintOperationAction(action), parent.native(), &err)
+	c := C.gtk_print_operation_run(po.native(), C.GtkPrintOperationAction(action), parent.toWindow(), &err)
 	res := PrintOperationResult(c)
 	if res == PRINT_OPERATION_RESULT_ERROR {
 		defer C.g_error_free(err)
@@ -948,8 +948,8 @@ func (po *PrintOperation) GetEmbedPageSetup() bool {
 }
 
 // PrintRunPageSetupDialog() is a wrapper around gtk_print_run_page_setup_dialog().
-func PrintRunPageSetupDialog(parent *Window, pageSetup *PageSetup, settings *PrintSettings) *PageSetup {
-	c := C.gtk_print_run_page_setup_dialog(parent.native(), pageSetup.native(), settings.native())
+func PrintRunPageSetupDialog(parent IWindow, pageSetup *PageSetup, settings *PrintSettings) *PageSetup {
+	c := C.gtk_print_run_page_setup_dialog(parent.toWindow(), pageSetup.native(), settings.native())
 	obj := glib.Take(unsafe.Pointer(c))
 	return wrapPageSetup(obj)
 }
@@ -973,7 +973,7 @@ var (
 )
 
 // PrintRunPageSetupDialogAsync() is a wrapper around gtk_print_run_page_setup_dialog_async().
-func PrintRunPageSetupDialogAsync(parent *Window, setup *PageSetup,
+func PrintRunPageSetupDialogAsync(parent IWindow, setup *PageSetup,
 	settings *PrintSettings, cb PageSetupDoneCallback, data uintptr) {
 
 	pageSetupDoneCallbackRegistry.Lock()
@@ -983,7 +983,7 @@ func PrintRunPageSetupDialogAsync(parent *Window, setup *PageSetup,
 		pageSetupDoneCallbackData{fn: cb, data: data}
 	pageSetupDoneCallbackRegistry.Unlock()
 
-	C._gtk_print_run_page_setup_dialog_async(parent.native(), setup.native(),
+	C._gtk_print_run_page_setup_dialog_async(parent.toWindow(), setup.native(),
 		settings.native(), C.gpointer(uintptr(id)))
 }
 


### PR DESCRIPTION
Allows using *gtk.ApplicationWindow and other "subclasses" of windows