### PR TITLE
Add gdk.EventCrossing mapping of GdkEventCrossing

### DIFF
--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -332,6 +332,36 @@ const (
 	GDK_EVENT_STOP      bool = C.GDK_EVENT_STOP != 0
 )
 
+// CrossingMode is a representation of GDK's GdkCrossingMode.
+
+type CrossingMode int
+
+const (
+	CROSSING_NORMAL CrossingMode = C.GDK_CROSSING_NORMAL
+	CROSSING_GRAB CrossingMode = C.GDK_CROSSING_GRAB
+	CROSSING_UNGRAB CrossingMode = C.GDK_CROSSING_UNGRAB
+	CROSSING_GTK_GRAB CrossingMode = C.GDK_CROSSING_GTK_GRAB
+	CROSSING_GTK_UNGRAB CrossingMode = C.GDK_CROSSING_GTK_UNGRAB
+	CROSSING_STATE_CHANGED CrossingMode = C.GDK_CROSSING_STATE_CHANGED
+	CROSSING_TOUCH_BEGIN CrossingMode = C.GDK_CROSSING_TOUCH_BEGIN
+	CROSSING_TOUCH_END CrossingMode = C.GDK_CROSSING_TOUCH_END
+	CROSSING_DEVICE_SWITCH CrossingMode = C.GDK_CROSSING_DEVICE_SWITCH
+)
+
+
+// NotifyType is a representation of GDK's GdkNotifyType.
+
+type NotifyType int
+
+const (
+	NOTIFY_ANCESTOR NotifyType = C.GDK_NOTIFY_ANCESTOR
+	NOTIFY_VIRTUAL NotifyType = C.GDK_NOTIFY_VIRTUAL
+	NOTIFY_INFERIOR NotifyType = C.GDK_NOTIFY_INFERIOR
+	NOTIFY_NONLINEAR NotifyType = C.GDK_NOTIFY_NONLINEAR
+	NOTIFY_NONLINEAR_VIRTUAL NotifyType = C.GDK_NOTIFY_NONLINEAR_VIRTUAL
+	NOTIFY_UNKNOWN NotifyType = C.GDK_NOTIFY_UNKNOWN
+)
+
 /*
  * GdkAtom
  */
@@ -1087,6 +1117,110 @@ func (v *EventMotion) State() ModifierType {
 	c := v.native().state
 	return ModifierType(c)
 }
+
+/*
+ * GdkEventCrossing
+ */
+
+// EventCrossing is a representation of GDK's GdkEventCrossing.
+type EventCrossing struct {
+	*Event
+}
+
+func EventCrossingNew() *EventCrossing {
+	ee := (*C.GdkEvent)(unsafe.Pointer(&C.GdkEventCrossing{}))
+	ev := Event{ee}
+	return &EventCrossing{&ev}
+}
+
+// EventCrossingNewFromEvent returns an EventCrossing from an Event.
+//
+// Using widget.Connect() for a key related signal such as
+// "enter-notify-event" results in a *Event being passed as
+// the callback's second argument. The argument is actually a
+// *EventCrossing. EventCrossingNewFromEvent provides a means of creating
+// an EventCrossing from the Event.
+func EventCrossingNewFromEvent(event *Event) *EventCrossing {
+	ee := (*C.GdkEvent)(unsafe.Pointer(event.native()))
+	ev := Event{ee}
+	return &EventCrossing{&ev}
+}
+
+// Native returns a pointer to the underlying GdkEventCrossing.
+func (v *EventCrossing) Native() uintptr {
+	return uintptr(unsafe.Pointer(v.native()))
+}
+
+func (v *EventCrossing) native() *C.GdkEventCrossing {
+	return (*C.GdkEventCrossing)(unsafe.Pointer(v.Event.native()))
+}
+
+func (v *EventCrossing) X() float64 {
+	c := v.native().x
+	return float64(c)
+}
+
+func (v *EventCrossing) Y() float64 {
+	c := v.native().y
+	return float64(c)
+}
+
+// XRoot returns the x coordinate of the pointer relative to the root of the screen.
+func (v *EventCrossing) XRoot() float64 {
+	c := v.native().x_root
+	return float64(c)
+}
+
+// YRoot returns the y coordinate of the pointer relative to the root of the screen.
+func (v *EventCrossing) YRoot() float64 {
+	c := v.native().y_root
+	return float64(c)
+}
+
+func (v *EventCrossing) State() uint {
+	c := v.native().state
+	return uint(c)
+}
+
+// Time returns the time of the event in milliseconds.
+func (v *EventCrossing) Time() uint32 {
+	c := v.native().time
+	return uint32(c)
+}
+
+func (v *EventCrossing) Type() EventType {
+	c := v.native()._type
+	return EventType(c)
+}
+
+func (v *EventCrossing) MotionVal() (float64, float64) {
+	x := v.native().x
+	y := v.native().y
+	return float64(x), float64(y)
+}
+
+func (v *EventCrossing) MotionValRoot() (float64, float64) {
+	x := v.native().x_root
+	y := v.native().y_root
+	return float64(x), float64(y)
+}
+
+func (v *EventCrossing) Mode() CrossingMode {
+	c := v.native().mode
+	return CrossingMode(c)
+}
+
+func (v *EventCrossing) Detail() NotifyType {
+	c := v.native().detail
+	return NotifyType(c)
+}
+
+
+func (v *EventCrossing) Focus() bool {
+	c := v.native().focus
+	return gobool(c)
+}
+
 
 /*
  * GdkEventScroll


### PR DESCRIPTION
Added `GdkEventCrossing` support, which is most of the time used to known when a user mouse over or leave a widget. Used in conjuction with `enter-notify-event` and `leave-notify-event` signals (which are already supported).

Gdk definition for `GdkEventCrossing`: https://github.com/linuxmint/gtk/blob/master/gdk/gdkevents.h#L831


Simple test if you want to check that it's working:

```
_, _ = window.Connect("leave-notify-event", func(w interface{}, e *gdk.Event) {
	event := gdk.EventCrossingNewFromEvent(e)

	fmt.Println(fmt.Sprintf("x=%v; y=%v; x_root=%v; y_root=%v; state=%v; time=%v; type=%v; mode=%v; detail=%v; focus=%v", event.X(), event.Y(), event.XRoot(), event.YRoot(), event.State(), event.Time(), event.Type(), event.Mode(), event.Detail(), event.Focus()))
})
```

When your mouse leave the window the console will print out: 

```
x=-10; y=207; x_root=1608; y_root=797; state=0; time=790639531; type=11; mode=0; detail=1; focus=false
```