### PR TITLE
gtk_widget_get_focus_on_click and gtk_widget_set_focus_on_click

### DIFF
--- a/gtk/widget_since_3_20.go
+++ b/gtk/widget_since_3_20.go
@@ -1,4 +1,4 @@
-//+build gtk_3_6 gtk_3_8 gtk_3_10 gtk_3_12 gtk_3_14 gtk_3_16 gtk_3_18
+// +build !gtk_3_6,!gtk_3_8,!gtk_3_10,!gtk_3_12,!gtk_3_14,!gtk_3_16,!gtk_3_18
 
 package gtk
 

--- a/gtk/widget_since_3_20.go
+++ b/gtk/widget_since_3_20.go
@@ -1,0 +1,17 @@
+//+build gtk_3_6 gtk_3_8 gtk_3_10 gtk_3_12 gtk_3_14 gtk_3_16 gtk_3_18
+
+package gtk
+
+// #include <gtk/gtk.h>
+import "C"
+
+// GetFocusOnClick is a wrapper around gtk_widget_get_focus_on_click().
+func (v *Widget) GetFocusOnClick() bool {
+	c := C.gtk_widget_get_focus_on_click(v.native())
+	return gobool(c)
+}
+
+// SetFocusOnClick is a wrapper around gtk_widget_set_focus_on_click().
+func (v *Widget) SetFocusOnClick(focusOnClick bool) {
+	C.gtk_widget_set_focus_on_click(v.native(), gbool(focusOnClick))
+}


### PR DESCRIPTION
Added `gtk_widget_get_focus_on_click()` and `gtk_widget_set_focus_on_click` mapping according to: https://developer.gnome.org/gtk3/stable/GtkWidget.html#gtk-widget-set-can-focus


**Please read carefully**: I feel like i've understood how `deprecated` and `since` works but for good measure double check that i haven't made any mistake on this.

I wanted to add functions that are available on Widget from gtk 3.20 and above