### PR TITLE
Add TextBuffer fnct and others

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -7921,8 +7921,8 @@ func (v *TextBuffer) CutClipboard(clipboard *Clipboard, defaultEditable bool) {
 	C.gtk_text_buffer_cut_clipboard(v.native(), clipboard.native(), gbool(defaultEditable))
 }
 
-// PastClipboard() is a wrapper around gtk_text_buffer_paste_clipboard().
-func (v *TextBuffer) PastClipboard(clipboard *Clipboard, overrideLocation *TextIter, defaultEditable bool) {
+// PasteClipboard() is a wrapper around gtk_text_buffer_paste_clipboard().
+func (v *TextBuffer) PasteClipboard(clipboard *Clipboard, overrideLocation *TextIter, defaultEditable bool) {
 	C.gtk_text_buffer_paste_clipboard(v.native(), clipboard.native(), (*C.GtkTextIter)(overrideLocation), gbool(defaultEditable))
 }
 

--- a/gtk/gtk_since_3_16.go
+++ b/gtk/gtk_since_3_16.go
@@ -128,3 +128,10 @@ func (v *StackSidebar) GetStack() *Stack {
 func (v *Entry) GrabFocusWithoutSelecting() {
 	C.gtk_entry_grab_focus_without_selecting(v.native())
 }
+
+// InsertMarkup() is a wrapper around  gtk_text_buffer_insert_markup()
+func (v *TextBuffer) InsertMarkup(start *TextIter, text string) {
+	cstr := C.CString(text)
+	defer C.free(unsafe.Pointer(cstr))
+	C.gtk_text_buffer_insert_markup(v.native(), (*C.GtkTextIter)(start), (*C.gchar)(cstr), C.gint(len(text)))
+}

--- a/gtk/text_iter.go
+++ b/gtk/text_iter.go
@@ -385,12 +385,32 @@ func (v *TextIter) InRange(v1 *TextIter, v2 *TextIter) bool {
 	return gobool(C.gtk_text_iter_in_range(v.native(), v1.native(), v2.native()))
 }
 
+// ForwardSearch is a wrapper around gtk_text_iter_forward_search().
+func (v *TextIter) ForwardSearch(text string, flags TextSearchFlags, limit *TextIter) (matchStart, matchEnd *TextIter, ok bool) {
+	cstr := C.CString(text)
+	defer C.free(unsafe.Pointer(cstr))
+
+	matchStart, matchEnd = new(TextIter), new(TextIter)
+	cbool := C.gtk_text_iter_forward_search(v.native(), (*C.gchar)(cstr), (C.GtkTextSearchFlags)(flags),
+		(*C.GtkTextIter)(matchStart), (*C.GtkTextIter)(matchEnd), (*C.GtkTextIter)(limit))
+	return matchStart, matchEnd, gobool(cbool)
+}
+
+// BackwardSearch is a wrapper around gtk_text_iter_backward_search().
+func (v *TextIter) BackwardSearch(text string, flags TextSearchFlags, limit *TextIter) (matchStart, matchEnd *TextIter, ok bool) {
+	cstr := C.CString(text)
+	defer C.free(unsafe.Pointer(cstr))
+
+	matchStart, matchEnd = new(TextIter), new(TextIter)
+	cbool := C.gtk_text_iter_backward_search(v.native(), (*C.gchar)(cstr), (C.GtkTextSearchFlags)(flags),
+		(*C.GtkTextIter)(matchStart), (*C.GtkTextIter)(matchEnd), (*C.GtkTextIter)(limit))
+	return matchStart, matchEnd, gobool(cbool)
+}
+
 // void 	gtk_text_iter_order ()
 // gboolean 	(*GtkTextCharPredicate) ()
 // gboolean 	gtk_text_iter_forward_find_char ()
 // gboolean 	gtk_text_iter_backward_find_char ()
-// gboolean 	gtk_text_iter_forward_search ()
-// gboolean 	gtk_text_iter_backward_search ()
 // gboolean 	gtk_text_iter_get_attributes ()
 // GtkTextIter * 	gtk_text_iter_copy ()
 // void 	gtk_text_iter_assign ()


### PR DESCRIPTION
Add TextBuffer fnct and others:
enum:
CornerType is a representation of GTK's GtkCornerType.
TextSearchFlags is a representation of GTK's GtkTextSearchFlags.
functions:
gtk_text_buffer_get_has_selection
gtk_text_buffer_get_selection_bound
gtk_text_buffer_get_selection_bounds
gtk_text_buffer_get_iter_at_line_offset
gtk_text_buffer_create_tag
gtk_text_buffer_remove_tag_by_name
gtk_text_buffer_register_serialize_tagset
gtk_text_buffer_register_deserialize_tagset
gtk_text_buffer_serialize
gtk_text_buffer_deserialize
gtk_text_buffer_get_insert
gtk_text_buffer_copy_clipboard
gtk_text_buffer_cut_clipboard
gtk_text_buffer_paste_clipboard
gtk_text_buffer_add_selection_clipboard
gtk_text_buffer_remove_selection_clipboard

Update text_iter search
enum: already added in gtk.go
functions:
gtk_text_iter_forward_search
gtk_text_iter_backward_search

Add TextBuffer fnct 3.16
function:
gtk_text_buffer_insert_markup

PS.
I take advantage that nothing is already merged to gather all this in one pull-request.
Regards.
