### PR TITLE
Add gtk_message_dialog_get_message_area()

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -5435,6 +5435,17 @@ func (v *MessageDialog) FormatSecondaryMarkup(format string, a ...interface{}) {
 		(*C.gchar)(cstr))
 }
 
+// GetMessageArea() is a wrapper around gtk_message_dialog_get_message_area().
+func (v *MessageDialog) GetMessageArea() (*Box, error) {
+	c := C.gtk_message_dialog_get_message_area(v.native())
+	if c == nil {
+		return nil, nilPtrErr
+	}
+	obj := glib.Take(unsafe.Pointer(c))
+	b := &Box{Container{Widget{glib.InitiallyUnowned{obj}}}}
+	return b, nil
+}
+
 /*
  * GtkNotebook
  */


### PR DESCRIPTION
Add MessageDialog:
gtk_message_dialog_get_message_area()

Hi, I leave a piece of code to quickly test the function:
```
package main

import (
	"log"

	"github.com/gotk3/gotk3/glib"
	"github.com/gotk3/gotk3/gtk"
)

func main() {
	var msgDialog *gtk.MessageDialog
	var err error
	var box *gtk.Box
	var lbl *gtk.Label
	var mainWin *gtk.Window

	gtk.Init(nil)
	if lbl, err = gtk.LabelNew(""); err == nil {
		lbl.SetMarkup(`<b><span foreground="#A40000FF">Inside the GtkBox</span></b>`)

		mainWin = makeWin("Parent window for test")
		msgDialog = gtk.MessageDialogNew(mainWin,
			gtk.DIALOG_MODAL,
			gtk.MESSAGE_INFO,
			gtk.BUTTONS_OK,
			"")

		msgDialog.SetTitle("Message dialog test")
		msgDialog.SetProperty("text", "primary text")
		msgDialog.SetProperty("secondary-text", "secondary text")
		// GetMessageArea
		if box, err = msgDialog.GetMessageArea(); err == nil {
			box.PackStart(lbl, true, true, 1)
			box.SetHAlign(gtk.ALIGN_FILL)
			box.ShowAll()
		}
	}
	if err != nil {
		log.Fatal("Unable to ... do what I want:", err)
	}
	var dispDialog = func() {
		_, err = glib.IdleAdd(func() {
			mainWin.ShowAll()
			msgDialog.Run()
			msgDialog.Close()
			mainWin.Destroy()
		})
		if err != nil {
			log.Fatal("Unable to launch goroutine:", err)
		}
	}
	go dispDialog()
	gtk.Main()
}

// Make window
func makeWin(title string) (mainWin *gtk.Window) {
	var err error
	if mainWin, err = gtk.WindowNew(gtk.WINDOW_TOPLEVEL); err == nil {
		mainWin.Connect("destroy", func() {
			gtk.MainQuit()
		})
		mainWin.SetDefaultSize(320, 240)
		mainWin.SetPosition(gtk.WIN_POS_CENTER)
		mainWin.SetTitle(title)
	} else {
		log.Fatal("Unable to create window:", err)
	}
	return
}

```
