### PR TITLE
adding treeview bindings (GetCellArea + funcs for coords conversion)

### DIFF
--- a/gtk/tree_view.go
+++ b/gtk/tree_view.go
@@ -120,6 +120,18 @@ func (v *TreeView) GetPathAtPos(x, y int, path *TreePath, column *TreeViewColumn
 		(*C.gint)(unsafe.Pointer(cellY)))
 }
 
+// GetCellArea is a wrapper around gtk_tree_view_get_cell_area().
+func (v *TreeView) GetCellArea(path *TreePath, column *TreeViewColumn) *gdk.Rectangle {
+	ctp := path.native()
+	pctvcol := column.native()
+
+	var rect C.GdkRectangle
+
+	C.gtk_tree_view_get_cell_area(v.native(), ctp, pctvcol, &rect)
+
+	return gdk.WrapRectangle(uintptr(unsafe.Pointer(&rect)))
+}
+
 // GetLevelIndentation is a wrapper around gtk_tree_view_get_level_indentation().
 func (v *TreeView) GetLevelIndentation() int {
 	return int(C.gtk_tree_view_get_level_indentation(v.native()))
@@ -450,7 +462,6 @@ func (v *TreeView) ScrollToCell(path *TreePath, column *TreeViewColumn, align bo
 // gint 	gtk_tree_view_insert_column_with_data_func ()
 // void 	gtk_tree_view_set_column_drag_function ()
 // gboolean 	gtk_tree_view_is_blank_at_pos ()
-// void 	gtk_tree_view_get_cell_area ()
 // void 	gtk_tree_view_get_background_area ()
 // void 	gtk_tree_view_get_visible_rect ()
 // gboolean 	gtk_tree_view_get_visible_range ()

--- a/gtk/tree_view.go
+++ b/gtk/tree_view.go
@@ -320,6 +320,27 @@ func (v *TreeView) GetBinWindow() *gdk.Window {
 	return w
 }
 
+// ConvertWidgetToBinWindowCoords is a rapper around
+// gtk_tree_view_convert_widget_to_bin_window_coords().
+func (v *TreeView) ConvertWidgetToBinWindowCoords(wx, wy int, bx, by *int) {
+	C.gtk_tree_view_convert_widget_to_bin_window_coords(
+		v.native(),
+		(C.gint)(wx),
+		(C.gint)(wy),
+		(*C.gint)(unsafe.Pointer(bx)),
+		(*C.gint)(unsafe.Pointer(by)))
+}
+
+// ConvertBinWindowToWidgetCoords is a rapper around
+// gtk_tree_view_convert_bin_window_to_widget_coords().
+func (v *TreeView) ConvertBinWindowToWidgetCoords(bx, by int, wx, wy *int) {
+	C.gtk_tree_view_convert_bin_window_to_widget_coords(v.native(),
+		(C.gint)(bx),
+		(C.gint)(by),
+		(*C.gint)(unsafe.Pointer(wx)),
+		(*C.gint)(unsafe.Pointer(wy)))
+}
+
 // SetEnableSearch is a wrapper around gtk_tree_view_set_enable_search().
 func (v *TreeView) SetEnableSearch(b bool) {
 	C.gtk_tree_view_set_enable_search(v.native(), gbool(b))
@@ -466,10 +487,8 @@ func (v *TreeView) ScrollToCell(path *TreePath, column *TreeViewColumn, align bo
 // void 	gtk_tree_view_get_visible_rect ()
 // gboolean 	gtk_tree_view_get_visible_range ()
 // void 	gtk_tree_view_convert_bin_window_to_tree_coords ()
-// void 	gtk_tree_view_convert_bin_window_to_widget_coords ()
 // void 	gtk_tree_view_convert_tree_to_bin_window_coords ()
 // void 	gtk_tree_view_convert_tree_to_widget_coords ()
-// void 	gtk_tree_view_convert_widget_to_bin_window_coords ()
 // void 	gtk_tree_view_convert_widget_to_tree_coords ()
 // void 	gtk_tree_view_enable_model_drag_dest ()
 // void 	gtk_tree_view_enable_model_drag_source ()


### PR DESCRIPTION
bindings for
* gtk_tree_view_get_cell_area()
* gtk_tree_view_convert_widget_to_bin_window_coords()
* gtk_tree_view_convert_bin_window_to_widget_coords()