### PR TITLE
fix could not determine kind of name for C.free

### DIFF
--- a/gtk/gtk_deprecated_since_3_16.go
+++ b/gtk/gtk_deprecated_since_3_16.go
@@ -2,6 +2,7 @@
 
 package gtk
 
+// #include <stdlib.h>
 // #include <gtk/gtk.h>
 // #include <stdlib.h>
 import "C"


### PR DESCRIPTION
fix gtk_since_3_16.go:158:8: could not determine kind of name for C.free