### PR TITLE
Pixbuf animation

### DIFF
--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -1771,6 +1771,7 @@ func marshalPixbufAnimation(p uintptr) (interface{}, error) {
 	return &PixbufAnimation{obj}, nil
 }
 
+// PixbufAnimationNewFromFile is a wrapper around gdk_pixbuf_animation_new_from_file().
 func PixbufAnimationNewFromFile(filename string) (*PixbufAnimation, error) {
 	cstr := C.CString(filename)
 	defer C.free(unsafe.Pointer(cstr))
@@ -1941,7 +1942,7 @@ func (v *PixbufLoader) GetAnimation() (*PixbufAnimation, error) {
 	return p, nil
 }
 
-// Conveignant function like above for Pixbuf. Write data, close loader return pixbufAnimation.
+// Convenient function like above for Pixbuf. Write data, close loader and return PixbufAnimation.
 func (v *PixbufLoader) WriteAndReturnPixbufAnimation(data []byte) (*PixbufAnimation, error) {
 
 	if len(data) == 0 {

--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -49,6 +49,7 @@ func init() {
 		{glib.Type(C.gdk_display_get_type()), marshalDisplay},
 		{glib.Type(C.gdk_drag_context_get_type()), marshalDragContext},
 		{glib.Type(C.gdk_pixbuf_get_type()), marshalPixbuf},
+		{glib.Type(C.gdk_pixbuf_animation_get_type()), marshalPixbufAnimation},
 		{glib.Type(C.gdk_rgba_get_type()), marshalRGBA},
 		{glib.Type(C.gdk_screen_get_type()), marshalScreen},
 		{glib.Type(C.gdk_visual_get_type()), marshalVisual},
@@ -1739,6 +1740,55 @@ func PixbufGetFileInfo(filename string) (format interface{}, width, height int) 
 }
 
 /*
+ * GdkPixbufAnimation
+ */
+
+// PixbufAnimation is a representation of GDK's GdkPixbufAnimation.
+type PixbufAnimation struct {
+	*glib.Object
+}
+
+// native returns a pointer to the underlying GdkPixbufAnimation.
+func (v *PixbufAnimation) native() *C.GdkPixbufAnimation {
+	if v == nil || v.GObject == nil {
+		return nil
+	}
+	p := unsafe.Pointer(v.GObject)
+	return C.toGdkPixbufAnimation(p)
+}
+
+func (v *PixbufAnimation) NativePrivate() *C.GdkPixbufAnimation {
+	if v == nil || v.GObject == nil {
+		return nil
+	}
+	p := unsafe.Pointer(v.GObject)
+	return C.toGdkPixbufAnimation(p)
+}
+
+func marshalPixbufAnimation(p uintptr) (interface{}, error) {
+	c := C.g_value_get_object((*C.GValue)(unsafe.Pointer(p)))
+	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
+	return &PixbufAnimation{obj}, nil
+}
+
+func PixbufAnimationNewFromFile(filename string) (*PixbufAnimation, error) {
+	cstr := C.CString(filename)
+	defer C.free(unsafe.Pointer(cstr))
+
+	var err *C.GError
+	c := C.gdk_pixbuf_animation_new_from_file((*C.char)(cstr), &err)
+	if c == nil {
+		defer C.g_error_free(err)
+		return nil, errors.New(C.GoString((*C.char)(err.message)))
+	}
+
+	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
+	p := &PixbufAnimation{obj}
+	runtime.SetFinalizer(p, func(_ interface{}) { obj.Unref() })
+	return p, nil
+}
+
+/*
  * GdkPixbufLoader
  */
 
@@ -1875,6 +1925,48 @@ func (v *PixbufLoader) GetPixbuf() (*Pixbuf, error) {
 	p := &Pixbuf{obj}
 	//obj.Ref() // Don't call Ref here, gdk_pixbuf_loader_get_pixbuf already did that for us.
 	runtime.SetFinalizer(p, func(_ interface{}) { obj.Unref() })
+	return p, nil
+}
+
+// GetAnimation is a wrapper around gdk_pixbuf_loader_get_animation().
+func (v *PixbufLoader) GetAnimation() (*PixbufAnimation, error) {
+	c := C.gdk_pixbuf_loader_get_animation(v.native())
+	if c == nil {
+		return nil, nilPtrErr
+	}
+
+	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
+	p := &PixbufAnimation{obj}
+	runtime.SetFinalizer(p, func(_ interface{}) { obj.Unref() })
+	return p, nil
+}
+
+// Conveignant function like above for Pixbuf. Write data, close loader return pixbufAnimation.
+func (v *PixbufLoader) WriteAndReturnPixbufAnimation(data []byte) (*PixbufAnimation, error) {
+
+	if len(data) == 0 {
+		return nil, errors.New("no data")
+	}
+
+	var err *C.GError
+	c := C.gdk_pixbuf_loader_write(v.native(), (*C.guchar)(unsafe.Pointer(&data[0])), C.gsize(len(data)), &err)
+
+	if !gobool(c) {
+		defer C.g_error_free(err)
+		return nil, errors.New(C.GoString((*C.char)(err.message)))
+	}
+
+	v.Close()
+
+	c2 := C.gdk_pixbuf_loader_get_animation(v.native())
+	if c2 == nil {
+		return nil, nilPtrErr
+	}
+
+	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c2))}
+	p := &PixbufAnimation{obj}
+	runtime.SetFinalizer(p, func(_ interface{}) { obj.Unref() })
+
 	return p, nil
 }
 

--- a/gdk/gdk.go.h
+++ b/gdk/gdk.go.h
@@ -61,6 +61,12 @@ toGdkPixbuf(void *p)
 	return (GDK_PIXBUF(p));
 }
 
+static GdkPixbufAnimation *
+toGdkPixbufAnimation(void *p)
+{
+	return (GDK_PIXBUF_ANIMATION(p));
+}
+
 static gboolean
 _gdk_pixbuf_save_png(GdkPixbuf *pixbuf,
 const char *filename, GError ** err, const char *compression)

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -4889,6 +4889,12 @@ func ImageNewFromAnimation(animation *gdk.PixbufAnimation) (*Image, error) {
 	return wrapImage(obj), nil
 }
 
+// SetFromAnimation is a wrapper around gtk_image_set_from_animation().
+func (v *Image) SetFromAnimation(animation *gdk.PixbufAnimation) {
+	pbaptr := (*C.GdkPixbufAnimation)(unsafe.Pointer(animation.NativePrivate()))
+	C.gtk_image_set_from_animation(v.native(), pbaptr)
+}
+
 // GetIconName() is a wrapper around gtk_image_get_icon_name().
 func (v *Image) GetIconName() (string, IconSize) {
 	var iconName *C.gchar

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -4870,11 +4870,24 @@ func (v *Image) GetIconSet() {
 }
 */
 
-// TODO(jrick) GdkPixbufAnimation
-/*
-func (v *Image) GetAnimation() {
+// GetAnimation() is a wrapper around gtk_image_get_animation()
+func (v *Image) GetAnimation() *gdk.PixbufAnimation {
+	c := C.gtk_image_get_animation(v.native())
+	if c == nil {
+		return nil
+	}
+	return &gdk.PixbufAnimation{glib.Take(unsafe.Pointer(c))}
 }
-*/
+
+// ImageNewFromAnimation() is a wrapper around gtk_image_new_from_animation()
+func ImageNewFromAnimation(animation *gdk.PixbufAnimation) (*Image, error) {
+	c := C.gtk_image_new_from_animation((*C.GdkPixbufAnimation)(animation.NativePrivate()))
+	if c == nil {
+		return nil, nilPtrErr
+	}
+	obj := glib.Take(unsafe.Pointer(c))
+	return wrapImage(obj), nil
+}
 
 // GetIconName() is a wrapper around gtk_image_get_icon_name().
 func (v *Image) GetIconName() (string, IconSize) {


### PR DESCRIPTION
GDK:
 
gdk.go.h:
- static GdkPixbufAnimation * declarationn  64-68

gdk.go: 
- RegisterGValueMarshalers  

- New PixbufAnimation structure declaration with native, NativePrivate, marshalPixbufAnimation

- gdk_pixbuf_animation_new_from_file()  

- gdk_pixbuf_loader_get_animation()    

Convenient function like for Pixbuf. Write data, close loader return pixbufAnimation.
- func (v *PixbufLoader) WriteAndReturnPixbufAnimation  
