### PR TITLE
Tree selection selected for each function

### DIFF
--- a/gtk/gtk.go.h
+++ b/gtk/gtk.go.h
@@ -965,3 +965,9 @@ static inline void _gtk_tree_model_foreach(GtkTreeModel *model, gpointer user_da
     gtk_tree_model_foreach(model, (GtkTreeModelForeachFunc)(goTreeModelForeachFunc), user_data);
 
 }
+
+extern void goTreeSelectionForeachFunc(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpointer data);
+
+static inline void _gtk_tree_selection_selected_foreach(GtkTreeSelection *selection, gpointer user_data) {
+    gtk_tree_selection_selected_foreach(selection, (GtkTreeSelectionForeachFunc)(goTreeSelectionForeachFunc), user_data);
+}

--- a/gtk/gtk_export.go
+++ b/gtk/gtk_export.go
@@ -148,3 +148,21 @@ func goTreeModelForeachFunc(model *C.GtkTreeModel, path *C.GtkTreePath, iter *C.
 		goIter,
 		r.userData))
 }
+
+//export goTreeSelectionForeachFunc
+func goTreeSelectionForeachFunc(model *C.GtkTreeModel, path *C.GtkTreePath, iter *C.GtkTreeIter, data C.gpointer) {
+	id := int(uintptr(data))
+
+	treeSelectionForeachFuncRegistry.Lock()
+	r := treeSelectionForeachFuncRegistry.m[id]
+	treeSelectionForeachFuncRegistry.Unlock()
+
+	goPath := &TreePath{(*C.GtkTreePath)(path)}
+	goIter := &TreeIter{(C.GtkTreeIter)(*iter)}
+
+	r.fn(
+		wrapTreeModel(glib.Take(unsafe.Pointer(model))),
+		goPath,
+		goIter,
+		r.userData)
+}


### PR DESCRIPTION
- Better performance than gtk.Selection.GetSelectedRows on very large entries (>15k).
- Plus, Iters and Paths are directly accessible without using glibList