### PR TITLE
Travis build using multiple gtk versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,54 @@
 language: go
 
-go:
-  - "1.8"
-  - "1.9"
-  - "1.10"
-  - "tip"
-
 go_import_path: github.com/gotk3/gotk3
 
 env:
   - GOARCH=amd64
 
-sudo: required
-dist: trusty
+jobs:
+  include:
+      # Testing on trusty, gtk 3.10
+    - os: linux
+      dist: trusty
+      go: "1.13"
+
+      # Testing on xenial, gtk 3.18
+    - os: linux
+      dist: xenial
+      go: "1.13"
+
+      # Testing on bionic, gtk 3.22
+      # Majority of the go versions here for compatibility checking
+    - os: linux
+      dist: bionic
+      go: "1.8"
+    - os: linux
+      dist: bionic
+      go: "1.9"
+    - os: linux
+      dist: bionic
+      go: "1.10"
+    - os: linux
+      dist: bionic
+      go: "1.11"
+    - os: linux
+      dist: bionic
+      go: "1.12"
+    - os: linux
+      dist: bionic
+      go: "1.13"
+    - os: linux
+      dist: bionic
+      go: tip
+
+addons:
+  apt:
+    packages:
+    - gtk+3.0
+    - libgtk-3-dev
+    - xvfb
 
 before_install:
-  - sudo apt-get update
-  - sudo apt-get install -y gtk+3.0 libgtk-3-dev
-  - sudo apt-get install -y xvfb
   - "export DISPLAY=:99.0"
   - sudo /usr/bin/Xvfb $DISPLAY 2>1 > /dev/null &
   - "export GTK_VERSION=$(pkg-config --modversion gtk+-3.0 | tr . _| cut -d '_' -f 1-2)"

--- a/gtk/glarea.go
+++ b/gtk/glarea.go
@@ -97,14 +97,14 @@ type MinorVersion int
 func (v *GLArea) GetRequiredVersion() (MajorVersion, MinorVersion) {
 	var major, minor int
 	C.gtk_gl_area_get_required_version(v.native(),
-		(*C.int)(unsafe.Pointer(&major)), (*C.int)(unsafe.Pointer(&minor)))
+		(*C.gint)(unsafe.Pointer(&major)), (*C.gint)(unsafe.Pointer(&minor)))
 
 	return MajorVersion(major), MinorVersion(minor)
 }
 
 // SetRequiredVersion is a wrapper around gtk_gl_area_set_required_version().
 func (v *GLArea) SetRequiredVersion(major, minor int) {
-	C.gtk_gl_area_set_required_version(v.native(), (C.int)(major), (C.int)(minor))
+	C.gtk_gl_area_set_required_version(v.native(), (C.gint)(major), (C.gint)(minor))
 }
 
 // HasDepthBuffer is a wrapper around gtk_gl_area_get_has_depth_buffer().


### PR DESCRIPTION
This PR utilizes all ubuntu distributions available on travis to cover more versions of gtk.

Also removes/replaces some obsolete bits, adds more golang versions and fixes a build issue on go 1.9 and lower in glarea.go.