### PR TITLE
socket and plug are reliant on X11, build it only on linux

### DIFF
--- a/gtk/socket_plug.go
+++ b/gtk/socket_plug.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package gtk
 
 // #include <gtk/gtkx.h>


### PR DESCRIPTION
closes #471 
GtkSocket and GtkPlug work only on linux, other parts of GTK are not reliant on these widgets, so just ignore them if not on linux.