### PR TITLE
Added support for GIcon

### DIFF
--- a/glib/gfile.go
+++ b/glib/gfile.go
@@ -1,0 +1,36 @@
+package glib
+
+// #include <gio/gio.h>
+// #include <glib.h>
+// #include <glib-object.h>
+// #include "glib.go.h"
+import "C"
+import "unsafe"
+
+type File struct {
+  *Object
+}
+
+// Native() returns a pointer to the underlying GFile.
+func (v *File ) Native() *C.GFile  {
+	if v == nil || v.GObject == nil {
+		return nil
+	}
+	return C.toGFile(unsafe.Pointer(v.GObject))
+}
+
+// FileNew is a wrapper around g_file_new_for_path().
+func FileNew(title string) *File {
+	cstr1 := (*C.gchar)(C.CString(title))
+	defer C.free(unsafe.Pointer(cstr1))
+
+	c := C.g_file_new_for_path(cstr1)
+	if c == nil {
+		return nil
+	}
+	return wrapFile(wrapObject(unsafe.Pointer(c)))
+}
+
+func wrapFile(obj *Object) *File {
+	return &File{obj}
+}

--- a/glib/gfile.go
+++ b/glib/gfile.go
@@ -21,7 +21,7 @@ func (v *File ) Native() *C.GFile  {
 
 // FileNew is a wrapper around g_file_new_for_path().
 func FileNew(title string) *File {
-	cstr1 := (*C.gchar)(C.CString(title))
+	cstr1 := (*C.char)(C.CString(title))
 	defer C.free(unsafe.Pointer(cstr1))
 
 	c := C.g_file_new_for_path(cstr1)

--- a/glib/gicon.go
+++ b/glib/gicon.go
@@ -1,0 +1,35 @@
+package glib
+
+// #include <gio/gio.h>
+// #include <glib.h>
+// #include <glib-object.h>
+// #include "glib.go.h"
+import "C"
+import "unsafe"
+
+type FileIcon struct {
+  *Object
+}
+
+// native() returns a pointer to the underlying GFileIcon.
+func (v *FileIcon) Native() *C.GFileIcon {
+	if v == nil || v.GObject == nil {
+		return nil
+	}
+	return C.toGFileIcon(unsafe.Pointer(v.GObject))
+}
+
+// FileIconNew is a wrapper around g_file_icon_new().
+func FileIconNew(path string) *FileIcon {
+  file := FileNew(path)
+
+	c := C.g_file_icon_new(file.Native())
+	if c == nil {
+		return nil
+	}
+	return wrapFileIcon(wrapObject(unsafe.Pointer(c)))
+}
+
+func wrapFileIcon(obj *Object) *FileIcon {
+	return &FileIcon{obj}
+}

--- a/glib/glib.go.h
+++ b/glib/glib.go.h
@@ -98,6 +98,23 @@ toGNotification(void *p)
 	return (G_NOTIFICATION(p));
 }
 
+static GIcon *
+toGIcon(void *p)
+{
+	return (G_ICON(p));
+}
+static GFileIcon *
+toGFileIcon(void *p)
+{
+	return (G_FILE_ICON(p));
+}
+
+static GFile *
+toGFile(void *p)
+{
+	return (G_FILE(p));
+}
+
 static GApplication *
 toGApplication(void *p)
 {

--- a/glib/notifications.go
+++ b/glib/notifications.go
@@ -97,9 +97,15 @@ func (v *Notification) AddButton(label, detailedAction string) {
 	C.g_notification_add_button(v.native(), cstr1, cstr2)
 }
 
+// SetIcon is a wrapper around g_notification_set_icon().
+func (v *Notification) SetIcon(iconPath string) {
+	fileIcon := FileIconNew(iconPath)
+
+	C.g_notification_set_icon(v.native(), (*C.GIcon)(fileIcon.Native()))
+}
+
 // void 	g_notification_set_default_action_and_target () // requires varargs
 // void 	g_notification_set_default_action_and_target_value () // requires variant
 // void 	g_notification_add_button_with_target () // requires varargs
 // void 	g_notification_add_button_with_target_value () //requires variant
 // void 	g_notification_set_urgent () // Deprecated, so not implemented
-// void 	g_notification_set_icon () // Requires support for GIcon, which we don't have yet.


### PR DESCRIPTION
GIcon needed minimal support for GFile
GFile uses a Go string to resolve the path
Implemented `Notification.SetIcon(path string)`
![image](https://user-images.githubusercontent.com/7088450/71716064-2af3df00-2dd9-11ea-8309-d44bb4d131ce.png)

Tested on Elementary OS 5.1
![image](https://user-images.githubusercontent.com/7088450/71716171-74dcc500-2dd9-11ea-80ce-72361f9ae2ef.png)