### PR TITLE
adding several bindings

### DIFF
--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -2147,7 +2147,7 @@ func wrapGeometry(obj *C.GdkGeometry) *Geometry {
 	return &Geometry{*obj}
 }
 
-// Native() returns a pointer to the underlying GdkGeometry.
+// native returns a pointer to the underlying GdkGeometry.
 func (r *Geometry) native() *C.GdkGeometry {
 	return &r.GdkGeometry
 }

--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -2123,6 +2123,140 @@ func (r *Rectangle) SetHeight(height int) {
 }
 
 /*
+ * GdkGeometry
+ */
+
+type Geometry struct {
+	GdkGeometry C.GdkGeometry
+}
+
+func WrapGeometry(p uintptr) *Geometry {
+	return wrapGeometry((*C.GdkGeometry)(unsafe.Pointer(p)))
+}
+
+func wrapGeometry(obj *C.GdkGeometry) *Geometry {
+	if obj == nil {
+		return nil
+	}
+	return &Geometry{*obj}
+}
+
+// Native() returns a pointer to the underlying GdkGeometry.
+func (r *Geometry) native() *C.GdkGeometry {
+	return &r.GdkGeometry
+}
+
+// GetMinWidth returns min_width field of the underlying GdkGeometry.
+func (r *Geometry) GetMinWidth() int {
+	return int(r.native().min_width)
+}
+
+// SetMinWidth sets min_width field of the underlying GdkGeometry.
+func (r *Geometry) SetMinWidth(minWidth int) {
+	r.native().min_width = C.gint(minWidth)
+}
+
+// GetMinHeight returns min_height field of the underlying GdkGeometry.
+func (r *Geometry) GetMinHeight() int {
+	return int(r.native().min_height)
+}
+
+// SetMinHeight sets min_height field of the underlying GdkGeometry.
+func (r *Geometry) SetMinHeight(minHeight int) {
+	r.native().min_height = C.gint(minHeight)
+}
+
+// GetMaxWidth returns max_width field of the underlying GdkGeometry.
+func (r *Geometry) GetMaxWidth() int {
+	return int(r.native().max_width)
+}
+
+// SetMaxWidth sets max_width field of the underlying GdkGeometry.
+func (r *Geometry) SetMaxWidth(maxWidth int) {
+	r.native().max_width = C.gint(maxWidth)
+}
+
+// GetMaxHeight returns max_height field of the underlying GdkGeometry.
+func (r *Geometry) GetMaxHeight() int {
+	return int(r.native().max_height)
+}
+
+// SetMaxHeight sets max_height field of the underlying GdkGeometry.
+func (r *Geometry) SetMaxHeight(maxHeight int) {
+	r.native().max_height = C.gint(maxHeight)
+}
+
+// GetBaseWidth returns base_width field of the underlying GdkGeometry.
+func (r *Geometry) GetBaseWidth() int {
+	return int(r.native().base_width)
+}
+
+// SetBaseWidth sets base_width field of the underlying GdkGeometry.
+func (r *Geometry) SetBaseWidth(baseWidth int) {
+	r.native().base_width = C.gint(baseWidth)
+}
+
+// GetBaseHeight returns base_height field of the underlying GdkGeometry.
+func (r *Geometry) GetBaseHeight() int {
+	return int(r.native().base_height)
+}
+
+// SetBaseHeight sets base_height field of the underlying GdkGeometry.
+func (r *Geometry) SetBaseHeight(baseHeight int) {
+	r.native().base_height = C.gint(baseHeight)
+}
+
+// GetWidthInc returns width_inc field of the underlying GdkGeometry.
+func (r *Geometry) GetWidthInc() int {
+	return int(r.native().width_inc)
+}
+
+// SetWidthInc sets width_inc field of the underlying GdkGeometry.
+func (r *Geometry) SetWidthInc(widthInc int) {
+	r.native().width_inc = C.gint(widthInc)
+}
+
+// GetHeightInc returns height_inc field of the underlying GdkGeometry.
+func (r *Geometry) GetHeightInc() int {
+	return int(r.native().height_inc)
+}
+
+// SetHeightInc sets height_inc field of the underlying GdkGeometry.
+func (r *Geometry) SetHeightInc(heightInc int) {
+	r.native().height_inc = C.gint(heightInc)
+}
+
+// GetMinAspect returns min_aspect field of the underlying GdkGeometry.
+func (r *Geometry) GetMinAspect() float64 {
+	return float64(r.native().min_aspect)
+}
+
+// SetMinAspect sets min_aspect field of the underlying GdkGeometry.
+func (r *Geometry) SetMinAspect(minAspect float64) {
+	r.native().min_aspect = C.gdouble(minAspect)
+}
+
+// GetMaxAspect returns max_aspect field of the underlying GdkGeometry.
+func (r *Geometry) GetMaxAspect() float64 {
+	return float64(r.native().max_aspect)
+}
+
+// SetMaxAspect sets max_aspect field of the underlying GdkGeometry.
+func (r *Geometry) SetMaxAspect(maxAspect float64) {
+	r.native().max_aspect = C.gdouble(maxAspect)
+}
+
+// GetWinGravity returns win_gravity field of the underlying GdkGeometry.
+// func (r *Geometry) GetWinGravity() GdkGravity {
+// 	r.native().win_gravity
+// }
+
+// SetWinGravity sets win_gravity field of the underlying GdkGeometry.
+func (r *Geometry) SetWinGravity(winGravity GdkGravity) {
+	r.native().win_gravity = C.GdkGravity(winGravity)
+}
+
+/*
  * GdkVisual
  */
 

--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -41,6 +41,7 @@ func init() {
 		{glib.Type(C.gdk_modifier_type_get_type()), marshalModifierType},
 		{glib.Type(C.gdk_pixbuf_alpha_mode_get_type()), marshalPixbufAlphaMode},
 		{glib.Type(C.gdk_event_mask_get_type()), marshalEventMask},
+		{glib.Type(C.gdk_gravity_get_type()), marshalGravity},
 
 		// Objects/Interfaces
 		{glib.Type(C.gdk_device_get_type()), marshalDevice},
@@ -1422,7 +1423,7 @@ func (v *EventConfigure) Height() int {
 /*
  * GdkGravity
  */
-type GdkGravity int
+type Gravity int
 
 const (
 	GDK_GRAVITY_NORTH_WEST = C.GDK_GRAVITY_NORTH_WEST
@@ -1436,6 +1437,11 @@ const (
 	GDK_GRAVITY_SOUTH_EAST = C.GDK_GRAVITY_SOUTH_EAST
 	GDK_GRAVITY_STATIC     = C.GDK_GRAVITY_STATIC
 )
+
+func marshalGravity(p uintptr) (interface{}, error) {
+	c := C.g_value_get_enum((*C.GValue)(unsafe.Pointer(p)))
+	return Gravity(c), nil
+}
 
 /*
  * GdkPixbuf
@@ -2247,12 +2253,12 @@ func (r *Geometry) SetMaxAspect(maxAspect float64) {
 }
 
 // GetWinGravity returns win_gravity field of the underlying GdkGeometry.
-// func (r *Geometry) GetWinGravity() GdkGravity {
-// 	r.native().win_gravity
-// }
+func (r *Geometry) GetWinGravity() Gravity {
+	return Gravity(r.native().win_gravity)
+}
 
 // SetWinGravity sets win_gravity field of the underlying GdkGeometry.
-func (r *Geometry) SetWinGravity(winGravity GdkGravity) {
+func (r *Geometry) SetWinGravity(winGravity Gravity) {
 	r.native().win_gravity = C.GdkGravity(winGravity)
 }
 

--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -288,6 +288,21 @@ const (
 	WINDOW_TYPE_HINT_DND           WindowTypeHint = C.GDK_WINDOW_TYPE_HINT_DND
 )
 
+// WindowHints is a representation of GDK's GdkWindowHints
+type WindowHints int
+
+const(
+	HINT_POS         WindowHints = C.GDK_HINT_POS
+	HINT_MIN_SIZE    WindowHints = C.GDK_HINT_MIN_SIZE
+	HINT_MAX_SIZE    WindowHints = C.GDK_HINT_MAX_SIZE
+	HINT_BASE_SIZE   WindowHints = C.GDK_HINT_BASE_SIZE
+	HINT_ASPECT      WindowHints = C.GDK_HINT_ASPECT
+	HINT_RESIZE_INC  WindowHints = C.GDK_HINT_RESIZE_INC
+	HINT_WIN_GRAVITY WindowHints = C.GDK_HINT_WIN_GRAVITY
+	HINT_USER_POS    WindowHints = C.GDK_HINT_USER_POS
+	HINT_USER_SIZE   WindowHints = C.GDK_HINT_USER_SIZE
+)
+
 // CURRENT_TIME is a representation of GDK_CURRENT_TIME
 
 const CURRENT_TIME = C.GDK_CURRENT_TIME

--- a/glib/glib.go
+++ b/glib/glib.go
@@ -1121,8 +1121,8 @@ type TypeMarshaler struct {
 }
 
 // RegisterGValueMarshalers adds marshalers for several types to the
-// internal marshalers map.  Once registered, calling GoValue on any
-// Value witha registered type will return the data returned by the
+// internal marshalers map. Once registered, calling GoValue on any
+// Value with a registered type will return the data returned by the
 // marshaler.
 func RegisterGValueMarshalers(tm []TypeMarshaler) {
 	gValueMarshalers.register(tm)

--- a/gtk/accel.go
+++ b/gtk/accel.go
@@ -417,7 +417,7 @@ func (v *Window) AddAccelGroup(accelGroup *AccelGroup) {
 	C.gtk_window_add_accel_group(v.native(), accelGroup.native())
 }
 
-// RemoveAccelGroup() is a wrapper around gtk_window_add_accel_group().
+// RemoveAccelGroup() is a wrapper around gtk_window_remove_accel_group().
 func (v *Window) RemoveAccelGroup(accelGroup *AccelGroup) {
 	C.gtk_window_remove_accel_group(v.native(), accelGroup.native())
 }

--- a/gtk/gdk.go
+++ b/gtk/gdk.go
@@ -18,3 +18,24 @@ func nativeGdkRectangle(rect gdk.Rectangle) *C.GdkRectangle {
 		height: C.int(rect.GetHeight()),
 	}
 }
+
+func nativeGdkGeometry(geom gdk.Geometry) *C.GdkGeometry {
+	// Note: Here we can't use geom.GdkGeometry because it would return
+	// C type prefixed with gdk package. A ways how to resolve this Go
+	// issue with same C structs in different Go packages is documented
+	// here https://github.com/golang/go/issues/13467 .
+	// This is the easiest way how to resolve the problem.
+	return &C.GdkGeometry{
+		min_width:   C.gint(geom.GetMinWidth()),
+		min_height:  C.gint(geom.GetMinHeight()),
+		max_width:   C.gint(geom.GetMaxWidth()),
+		max_height:  C.gint(geom.GetMaxHeight()),
+		base_width:  C.gint(geom.GetBaseWidth()),
+		base_height: C.gint(geom.GetBaseHeight()),
+		width_inc:   C.gint(geom.GetWidthInc()),
+		height_inc:  C.gint(geom.GetHeightInc()),		
+		min_aspect:  C.gdouble(geom.GetMinAspect()),
+		max_aspect:  C.gdouble(geom.GetMaxAspect()),
+		win_gravity: C.GdkGravity(geom.GetWinGravity()),
+	}
+}

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -3579,18 +3579,19 @@ func (v *Entry) SetIconDragSource() {
 }
 */
 
-// GetCurrentIconDragSource() is a wrapper around
-// gtk_entry_get_current_icon_drag_source().
+// GetCurrentIconDragSource() is a wrapper around gtk_entry_get_current_icon_drag_source().
 func (v *Entry) GetCurrentIconDragSource() int {
 	c := C.gtk_entry_get_current_icon_drag_source(v.native())
 	return int(c)
 }
 
-// TODO(jrick) GdkRectangle
-/*
-func (v *Entry) GetIconArea() {
+// GetIconArea is a wrapper around gtk_entry_get_icon_area().
+func (v *Entry) GetIconArea(iconPos EntryIconPosition) *gdk.Rectangle {
+	var cRect *C.GdkRectangle
+	C.gtk_entry_get_icon_area(v.native(), C.GtkEntryIconPosition(iconPos), cRect)
+	iconArea := gdk.WrapRectangle(uintptr(unsafe.Pointer(cRect)))
+	return iconArea
 }
-*/
 
 // SetInputPurpose() is a wrapper around gtk_entry_set_input_purpose().
 func (v *Entry) SetInputPurpose(purpose InputPurpose) {

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -3217,7 +3217,7 @@ func (v *Entry) GetTextLength() uint16 {
 // GetTextArea is a wrapper around gtk_entry_get_text_area().
 func (v *Entry) GetTextArea() *gdk.Rectangle {
 	var cRect *C.GdkRectangle
-	wasRetrieved := C.gtk_entry_get_text_area(v.native(), cRect)
+	C.gtk_entry_get_text_area(v.native(), cRect)
 	textArea := gdk.WrapRectangle(uintptr(unsafe.Pointer(cRect)))
 	return textArea
 }

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -3214,11 +3214,13 @@ func (v *Entry) GetTextLength() uint16 {
 	return uint16(c)
 }
 
-// TODO(jrick) GdkRectangle
-/*
-func (v *Entry) GetTextArea() {
+// GetTextArea is a wrapper around gtk_entry_get_text_area().
+func (v *Entry) GetTextArea() *gdk.Rectangle {
+	var cRect *C.GdkRectangle
+	wasRetrieved := C.gtk_entry_get_text_area(v.native(), cRect)
+	textArea := gdk.WrapRectangle(uintptr(unsafe.Pointer(cRect)))
+	return textArea
 }
-*/
 
 // SetVisibility() is a wrapper around gtk_entry_set_visibility().
 func (v *Entry) SetVisibility(visible bool) {

--- a/gtk/gtk_deprecated_since_3_14.go
+++ b/gtk/gtk_deprecated_since_3_14.go
@@ -55,7 +55,7 @@ func (v *Window) ResizeGripIsVisible() bool {
 }
 
 // GetResizeGripArea is a wrapper around gtk_window_get_resize_grip_area().
-func (v *Window) GetResizeGripArea() (gdk.Rectangle, bool) {
+func (v *Window) GetResizeGripArea() (*gdk.Rectangle, bool) {
 	var cRect *C.GdkRectangle
 	wasRetrieved := C.gtk_window_get_resize_grip_area(v.native(), cRect)
 	rect := gdk.WrapRectangle(uintptr(unsafe.Pointer(cRect)))

--- a/gtk/gtk_deprecated_since_3_14.go
+++ b/gtk/gtk_deprecated_since_3_14.go
@@ -37,13 +37,6 @@ func init() {
  * deprecated since version 3.14 and should not be used in newly-written code
  */
 
-// ResizeGripIsVisible is a wrapper around
-// gtk_window_resize_grip_is_visible().
-func (v *Window) ResizeGripIsVisible() bool {
-	c := C.gtk_window_resize_grip_is_visible(v.native())
-	return gobool(c)
-}
-
 // SetHasResizeGrip is a wrapper around gtk_window_set_has_resize_grip().
 func (v *Window) SetHasResizeGrip(setting bool) {
 	C.gtk_window_set_has_resize_grip(v.native(), gbool(setting))
@@ -53,6 +46,20 @@ func (v *Window) SetHasResizeGrip(setting bool) {
 func (v *Window) GetHasResizeGrip() bool {
 	c := C.gtk_window_get_has_resize_grip(v.native())
 	return gobool(c)
+}
+
+// ResizeGripIsVisible is a wrapper around gtk_window_resize_grip_is_visible().
+func (v *Window) ResizeGripIsVisible() bool {
+	c := C.gtk_window_resize_grip_is_visible(v.native())
+	return gobool(c)
+}
+
+// GetResizeGripArea is a wrapper around gtk_window_get_resize_grip_area().
+func (v *Window) GetResizeGripArea() (gdk.Rectangle, bool) {
+	var cRect *C.GdkRectangle
+	wasRetrieved := C.gtk_window_get_resize_grip_area(v.native(), cRect)
+	rect := gdk.WrapRectangle(uintptr(unsafe.Pointer(cRect)))
+	return rect, gobool(wasRetrieved)
 }
 
 // Reparent() is a wrapper around gtk_widget_reparent().

--- a/gtk/gtk_deprecated_since_3_20.go
+++ b/gtk/gtk_deprecated_since_3_20.go
@@ -5,6 +5,9 @@ package gtk
 // #include <gtk/gtk.h>
 // #include <stdlib.h>
 import "C"
+import (
+	"unsafe"
+)
 
 // GetFocusOnClick() is a wrapper around gtk_button_get_focus_on_click().
 func (v *Button) GetFocusOnClick() bool {
@@ -19,9 +22,9 @@ func (v *TextIter) BeginsTag(v1 *TextTag) bool {
 
 // ParseGeometry is a wrapper around gtk_window_parse_geometry().
 func (v *Window) ParseGeometry(geometry string) bool {
-	cstr := C.CString(file)
+	cstr := C.CString(geometry)
 	defer C.free(unsafe.Pointer(cstr))
-	c := C.gtk_window_parse_geometry((*C.gchar)(cstr))
+	c := C.gtk_window_parse_geometry(v.native(), (*C.gchar)(cstr))
 	return gobool(c)
 }
 

--- a/gtk/gtk_deprecated_since_3_20.go
+++ b/gtk/gtk_deprecated_since_3_20.go
@@ -17,6 +17,14 @@ func (v *TextIter) BeginsTag(v1 *TextTag) bool {
 	return gobool(C.gtk_text_iter_begins_tag(v.native(), v1.native()))
 }
 
+// ParseGeometry is a wrapper around gtk_window_parse_geometry().
+func (v *Window) ParseGeometry(geometry string) bool {
+	cstr := C.CString(file)
+	defer C.free(unsafe.Pointer(cstr))
+	c := C.gtk_window_parse_geometry((*C.gchar)(cstr))
+	return gobool(c)
+}
+
 // ResizeToGeometry is a wrapper around gtk_window_resize_to_geometry().
 func (v *Window) ResizeToGeometry(width, height int) {
 	C.gtk_window_resize_to_geometry(v.native(), C.gint(width), C.gint(height))

--- a/gtk/gtk_since_3_12.go
+++ b/gtk/gtk_since_3_12.go
@@ -449,11 +449,11 @@ func (v *Popover) SetPointingTo(rect gdk.Rectangle) {
 }
 
 // GetPointingTo is a wrapper around gtk_popover_get_pointing_to().
-func (v *Popover) GetPointingTo(rect *gdk.Rectangle) bool {
-	var crect C.GdkRectangle
-	isSet := C.gtk_popover_get_pointing_to(v.native(), &crect)
-	*rect = *gdk.WrapRectangle(uintptr(unsafe.Pointer(&crect)))
-	return gobool(isSet)
+func (v *Popover) GetPointingTo() (*gdk.Rectangle, bool) {
+	var cRect *C.GdkRectangle
+	isSet := C.gtk_popover_get_pointing_to(v.native(), cRect)
+	rect := gdk.WrapRectangle(uintptr(unsafe.Pointer(cRect)))
+	return rect, gobool(isSet)
 }
 
 // SetPosition is a wrapper around gtk_popover_set_position().

--- a/gtk/menu_since_3_22.go
+++ b/gtk/menu_since_3_22.go
@@ -18,7 +18,7 @@ func (v *Menu) PopupAtPointer(triggerEvent *gdk.Event) {
 }
 
 // PopupAtWidget() is a wrapper for gtk_menu_popup_at_widget()
-func (v *Menu) PopupAtWidget(widget IWidget, widgetAnchor gdk.GdkGravity, menuAnchor gdk.GdkGravity, triggerEvent *gdk.Event) {
+func (v *Menu) PopupAtWidget(widget IWidget, widgetAnchor gdk.Gravity, menuAnchor gdk.Gravity, triggerEvent *gdk.Event) {
 	e := (*C.GdkEvent)(unsafe.Pointer(triggerEvent.Native()))
 	C.gtk_menu_popup_at_widget(v.native(), widget.toWidget(), C.GdkGravity(widgetAnchor), C.GdkGravity(menuAnchor), e)
 }

--- a/gtk/widget.go
+++ b/gtk/widget.go
@@ -260,9 +260,9 @@ func (v *Widget) Activate() bool {
 }
 
 // Intersect is a wrapper around gtk_widget_intersect().
-func (v *Widget) Intersect(area *gdk.Rectangle) (*gdk.Rectangle, bool) {
+func (v *Widget) Intersect(area gdk.Rectangle) (*gdk.Rectangle, bool) {
 	var cRect *C.GdkRectangle
-	hadIntersection := C.gtk_widget_intersect(v.native(), cRect)
+	hadIntersection := C.gtk_widget_intersect(v.native(), nativeGdkRectangle(area), cRect)
 	intersection := gdk.WrapRectangle(uintptr(unsafe.Pointer(cRect)))
 	return intersection, gobool(hadIntersection)
 }

--- a/gtk/widget.go
+++ b/gtk/widget.go
@@ -259,11 +259,13 @@ func (v *Widget) Activate() bool {
 	return gobool(C.gtk_widget_activate(v.native()))
 }
 
-// TODO(jrick) GdkRectangle
-/*
-func (v *Widget) Intersect() {
+// Intersect is a wrapper around gtk_widget_intersect().
+func (v *Widget) Intersect(area *gdk.Rectangle) (*gdk.Rectangle, bool) {
+	var cRect *C.GdkRectangle
+	hadIntersection := C.gtk_widget_intersect(v.native(), cRect)
+	intersection := gdk.WrapRectangle(uintptr(unsafe.Pointer(cRect)))
+	return intersection, gobool(hadIntersection)
 }
-*/
 
 // IsFocus() is a wrapper around gtk_widget_is_focus().
 func (v *Widget) IsFocus() bool {

--- a/gtk/window.go
+++ b/gtk/window.go
@@ -117,11 +117,14 @@ func WindowSetDefaultIcon(icon *gdk.Pixbuf) {
 	C.gtk_window_set_default_icon(iconPtr)
 }
 
-// TODO(jrick) GdkGeometry GdkWindowHints.
-/*
-func (v *Window) SetGeometryHints() {
+// SetGeometryHints is a wrapper around gtk_window_set_geometry_hints().
+func (v *Window) SetGeometryHints(geometryWidget IWidget, geometry gdk.Geometry, geometryMask gdk.WindowHints) {
+	var gW *C.GtkWidget = nil
+	if geometryWidget != nil {
+		gW = geometryWidget.toWidget()
+	}
+	C.gtk_window_set_geometry_hints(v.native(), gW, geometry, geometryMask)
 }
-*/
 
 // SetGravity is a wrapper around gtk_window_set_gravity().
 func (v *Window) SetGravity(gravity gdk.GdkGravity) {

--- a/gtk/window.go
+++ b/gtk/window.go
@@ -123,7 +123,7 @@ func (v *Window) SetGeometryHints(geometryWidget IWidget, geometry gdk.Geometry,
 	if geometryWidget != nil {
 		gW = geometryWidget.toWidget()
 	}
-	C.gtk_window_set_geometry_hints(v.native(), gW, nativeGdkGeometry(geometry), C.gint(geometryMask))
+	C.gtk_window_set_geometry_hints(v.native(), gW, nativeGdkGeometry(geometry), C.GdkWindowHints(geometryMask))
 }
 
 // SetGravity is a wrapper around gtk_window_set_gravity().

--- a/gtk/window.go
+++ b/gtk/window.go
@@ -621,4 +621,3 @@ func (v *Window) SetMnemonicModifier(mods gdk.ModifierType) {
 // TODO gtk_window_set_default_icon_list().
 // TODO gtk_window_set_icon_list().
 // TODO gtk_window_set_screen().
-// TODO gtk_window_get_resize_grip_area().

--- a/gtk/window.go
+++ b/gtk/window.go
@@ -617,7 +617,6 @@ func (v *Window) SetMnemonicModifier(mods gdk.ModifierType) {
 // TODO gtk_window_get_icon_list().
 // TODO gtk_window_get_window_type().
 // TODO gtk_window_list_toplevels().
-// TODO gtk_window_parse_geometry().
 // TODO gtk_window_propagate_key_event().
 // TODO gtk_window_set_default_icon_list().
 // TODO gtk_window_set_icon_list().

--- a/gtk/window.go
+++ b/gtk/window.go
@@ -131,11 +131,11 @@ func (v *Window) SetGravity(gravity gdk.Gravity) {
 	C.gtk_window_set_gravity(v.native(), C.GdkGravity(gravity))
 }
 
-// TODO(jrick) GdkGravity.
-/*
-func (v *Window) GetGravity() {
+// GetGravity is a wrapper around gtk_window_get_gravity().
+func (v *Window) GetGravity() gdk.Gravity {
+	c := C.gtk_window_get_gravity(v.native())
+	return gdk.Gravity(c)
 }
-*/
 
 // SetPosition is a wrapper around gtk_window_set_position().
 func (v *Window) SetPosition(position WindowPosition) {

--- a/gtk/window.go
+++ b/gtk/window.go
@@ -127,7 +127,7 @@ func (v *Window) SetGeometryHints(geometryWidget IWidget, geometry gdk.Geometry,
 }
 
 // SetGravity is a wrapper around gtk_window_set_gravity().
-func (v *Window) SetGravity(gravity gdk.GdkGravity) {
+func (v *Window) SetGravity(gravity gdk.Gravity) {
 	C.gtk_window_set_gravity(v.native(), C.GdkGravity(gravity))
 }
 

--- a/gtk/window.go
+++ b/gtk/window.go
@@ -118,12 +118,12 @@ func WindowSetDefaultIcon(icon *gdk.Pixbuf) {
 }
 
 // SetGeometryHints is a wrapper around gtk_window_set_geometry_hints().
-func (v *Window) SetGeometryHints(geometryWidget IWidget, geometry *gdk.Geometry, geometryMask gdk.WindowHints) {
+func (v *Window) SetGeometryHints(geometryWidget IWidget, geometry gdk.Geometry, geometryMask gdk.WindowHints) {
 	var gW *C.GtkWidget = nil
 	if geometryWidget != nil {
 		gW = geometryWidget.toWidget()
 	}
-	C.gtk_window_set_geometry_hints(v.native(), gW, geometry, geometryMask)
+	C.gtk_window_set_geometry_hints(v.native(), gW, nativeGdkGeometry(geometry), C.gint(geometryMask))
 }
 
 // SetGravity is a wrapper around gtk_window_set_gravity().

--- a/gtk/window.go
+++ b/gtk/window.go
@@ -118,7 +118,7 @@ func WindowSetDefaultIcon(icon *gdk.Pixbuf) {
 }
 
 // SetGeometryHints is a wrapper around gtk_window_set_geometry_hints().
-func (v *Window) SetGeometryHints(geometryWidget IWidget, geometry gdk.Geometry, geometryMask gdk.WindowHints) {
+func (v *Window) SetGeometryHints(geometryWidget IWidget, geometry *gdk.Geometry, geometryMask gdk.WindowHints) {
 	var gW *C.GtkWidget = nil
 	if geometryWidget != nil {
 		gW = geometryWidget.toWidget()


### PR DESCRIPTION
adds bindings for
* GdkWindowHints
* GdkGeometry
* gtk_window_set_geometry_hints()
* gtk_window_get_gravity()
* gtk_window_parse_geometry()
* gtk_window_get_resize_grip_area()
* gtk_widget_intersect()
* gtk_entry_get_text_area()
* gtk_entry_get_icon_area()

renames GdkGravity to Gravity to align with naming conventions.  
adjust GetPointingTo() to conform to golang coding conventions.