### PR TITLE
Testing-related functions

### DIFF
--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -9,5 +9,5 @@
   - [raichu](https://github.com/raichu/gotk3)
   - [juniorz](https://github.com/juniorz)
   - [thanhps42](https://github.com/thanhps42)
-  - [MJacred](https://github.com/MJacred/gotk3)
+  - [cubiest](https://github.com/cubiest/gotk3) - [MJacred](https://github.com/MJacred) & [founderio](https://github.com/founderio)
   - you?

--- a/gdk/testing.go
+++ b/gdk/testing.go
@@ -1,0 +1,38 @@
+package gdk
+
+// #include <gdk/gdk.h>
+import "C"
+
+// TestRenderSync retrieves a pixel from window to force the windowing system to carry out any pending rendering commands.
+// This function is intended to be used to synchronize with rendering pipelines, to benchmark windowing system rendering operations.
+// This is a wrapper around gdk_test_render_sync().
+func TestRenderSync(window *Window) {
+	C.gdk_test_render_sync(window.native())
+}
+
+// TestSimulateButton simulates a single mouse button event (press or release) at the given coordinates relative to the window.
+// Hint: a single click of a button requires this method to be called twice, once for pressed and once for released.
+// In most cases, gtk.TestWidgetClick() should be used.
+//
+// button: Mouse button number, starts with 0
+// modifiers: Keyboard modifiers for the button event
+// buttonPressRelease: either GDK_BUTTON_PRESS or GDK_BUTTON_RELEASE
+//
+// This is a wrapper around gdk_test_simulate_button().
+func TestSimulateButton(window *Window, x, y int, button uint, modifiers ModifierType, buttonPressRelease EventType) bool {
+	return gobool(C.gdk_test_simulate_button(window.native(), C.gint(x), C.gint(y), C.guint(button), C.GdkModifierType(modifiers), C.GdkEventType(buttonPressRelease)))
+}
+
+// TestSimulateButton simulates a keyboard event (press or release) at the given coordinates relative to the window.
+// If the coordinates (-1, -1) are used, the window origin is used instead.
+// Hint: a single key press requires this method to be called twice, once for pressed and once for released.
+// In most cases, gtk.TestWidgetSendKey() should be used.
+//
+// keyval: A GDK keyboard value (See KeyvalFromName(), UnicodeToKeyval(), ...)
+// modifiers: Keyboard modifiers for the key event
+// buttonPressRelease: either GDK_BUTTON_PRESS or GDK_BUTTON_RELEASE
+//
+// This is a wrapper around gdk_test_simulate_key().
+func TestSimulateKey(window *Window, x, y int, keyval uint, modifiers ModifierType, buttonPressRelease EventType) bool {
+	return gobool(C.gdk_test_simulate_key(window.native(), C.gint(x), C.gint(y), C.guint(keyval), C.GdkModifierType(modifiers), C.GdkEventType(buttonPressRelease)))
+}

--- a/glib/glib.go
+++ b/glib/glib.go
@@ -121,6 +121,23 @@ func (t Type) Parent() Type {
 	return Type(C.g_type_parent(C.GType(t)))
 }
 
+// IsA is a wrapper around g_type_is_a().
+func (t Type) IsA(isAType Type) bool {
+	return gobool(C.g_type_is_a(C.GType(t), C.GType(isAType)))
+}
+
+// TypeFromName is a wrapper around g_type_from_name
+func TypeFromName(typeName string) Type {
+	cstr := (*C.gchar)(C.CString(typeName))
+	defer C.free(unsafe.Pointer(cstr))
+	return Type(C.g_type_from_name(cstr))
+}
+
+//TypeNextBase is a wrapper around g_type_next_base
+func TypeNextBase(leafType, rootType Type) Type {
+	return Type(C.g_type_next_base(C.GType(leafType), C.GType(rootType)))
+}
+
 // UserDirectory is a representation of GLib's GUserDirectory.
 type UserDirectory int
 

--- a/glib/glib_test.go
+++ b/glib/glib_test.go
@@ -56,3 +56,36 @@ func TestTimeoutAdd(t *testing.T) {
 
 	gtk.Main()
 }
+
+// TestTypeNames tests both glib.TypeFromName and glib.Type.Name
+func TestTypeNames(t *testing.T) {
+	tp := glib.TypeFromName("GtkWindow")
+	name := tp.Name()
+
+	if name != "GtkWindow" {
+		t.Error("Expected GtkWindow, got", name)
+	}
+}
+
+func TestTypeIsA(t *testing.T) {
+	tp := glib.TypeFromName("GtkApplicationWindow")
+	tpParent := glib.TypeFromName("GtkWindow")
+
+	isA := tp.IsA(tpParent)
+
+	if !isA {
+		t.Error("Expected true, GtkApplicationWindow is a GtkWindow")
+	}
+}
+
+func TestTypeNextBase(t *testing.T) {
+	tpLeaf := glib.TypeFromName("GtkWindow")
+	tpParent := glib.TypeFromName("GtkContainer")
+
+	tpNextBase := glib.TypeNextBase(tpLeaf, tpParent)
+	name := tpNextBase.Name()
+
+	if name != "GtkBin" {
+		t.Error("Expected GtkBin, got", name)
+	}
+}

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -9976,3 +9976,24 @@ func cast(c *C.GObject) (glib.IObject, error) {
 
 	return ret, nil
 }
+
+// cast takes a native GtkWidget and casts it to the appropriate Go struct.
+func castWidget(c *C.GtkWidget) (IWidget, error) {
+	var (
+		className = goString(C.object_get_class_name(C.toGObject(unsafe.Pointer(c))))
+		obj       = glib.Take(unsafe.Pointer(c))
+	)
+
+	intf, err := castInternal(className, obj)
+	if err != nil {
+		return nil, err
+	}
+
+	ret, ok := intf.(IWidget)
+	if !ok {
+		return nil, errors.New("did not return an IWidget")
+	}
+
+	return ret, nil
+}
+

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -9921,36 +9921,55 @@ var WrapMap = map[string]WrapFn{
 	"GtkWindow":               wrapWindow,
 }
 
+// castInternal casts the given object to the appropriate Go struct, but returns it as interface for later type assertions.
+// The className is the results of C.object_get_class_name(c) called on the native object.
+// The obj is the result of glib.Take(unsafe.Pointer(c)), used as a parameter for the wrapper functions.
+func castInternal(className string, obj *glib.Object) (interface{}, error) {
+	fn, ok := WrapMap[className]
+	if !ok {
+		return nil, errors.New("unrecognized class name '" + className + "'")
+	}
+
+	// Check that the wrapper function is actually a function
+	rf := reflect.ValueOf(fn)
+	if rf.Type().Kind() != reflect.Func {
+		return nil, errors.New("wraper is not a function")
+	}
+
+	// Call the wraper function with the *glib.Object as first parameter
+	// e.g. "wrapWindow(obj)"
+	v := reflect.ValueOf(obj)
+	rv := rf.Call([]reflect.Value{v})
+
+	// At most/max 1 return value
+	if len(rv) != 1 {
+		return nil, errors.New("wrapper did not return")
+	}
+
+	// Needs to be a pointer of some sort
+	if k := rv[0].Kind(); k != reflect.Ptr {
+		return nil, fmt.Errorf("wrong return type %s", k)
+	}
+
+	// Only get an interface value, type check will be done in more specific functions
+	return rv[0].Interface(), nil
+}
+
 // cast takes a native GObject and casts it to the appropriate Go struct.
 //TODO change all wrapFns to return an IObject
+//^- not sure about this TODO. This may make some usages of the wrapper functions quite verbose, no?
 func cast(c *C.GObject) (glib.IObject, error) {
 	var (
 		className = goString(C.object_get_class_name(c))
 		obj       = glib.Take(unsafe.Pointer(c))
 	)
 
-	fn, ok := WrapMap[className]
-	if !ok {
-		return nil, errors.New("unrecognized class name '" + className + "'")
+	intf, err := castInternal(className, obj)
+	if err != nil {
+		return nil, err
 	}
 
-	rf := reflect.ValueOf(fn)
-	if rf.Type().Kind() != reflect.Func {
-		return nil, errors.New("wraper is not a function")
-	}
-
-	v := reflect.ValueOf(obj)
-	rv := rf.Call([]reflect.Value{v})
-
-	if len(rv) != 1 {
-		return nil, errors.New("wrapper did not return")
-	}
-
-	if k := rv[0].Kind(); k != reflect.Ptr {
-		return nil, fmt.Errorf("wrong return type %s", k)
-	}
-
-	ret, ok := rv[0].Interface().(glib.IObject)
+	ret, ok := intf.(glib.IObject)
 	if !ok {
 		return nil, errors.New("did not return an IObject")
 	}

--- a/gtk/gtk.go.h
+++ b/gtk/gtk.go.h
@@ -783,6 +783,13 @@ set_type(GType *types, int n, GType t)
 	types[n] = t;
 }
 
+// _gtk_test_init is a wrapper to use gtk_test_init directly from go.
+// The variadic part on gtk_test_init is not used at the moment, according to the documentation.
+static void _gtk_test_init(int *argcp, char ***argvp)
+{
+	gtk_test_init(argcp, argvp);
+}
+
 static GtkTreeViewColumn *
 _gtk_tree_view_column_new_with_attributes_one(const gchar *title,
     GtkCellRenderer *renderer, const gchar *attribute, gint column)

--- a/gtk/gtk.go.h
+++ b/gtk/gtk.go.h
@@ -766,6 +766,12 @@ toGdkPixbuf(void *p)
 	return (GDK_PIXBUF(p));
 }
 
+static GObject *
+toGObject(void *p)
+{
+	return (G_OBJECT(p));
+}
+
 static GType *
 alloc_types(int n) {
 	return ((GType *)g_new0(GType, n));

--- a/gtk/testing.go
+++ b/gtk/testing.go
@@ -1,0 +1,162 @@
+package gtk
+
+// #include <gtk/gtk.h>
+// #include "gtk.go.h"
+import "C"
+import (
+	"errors"
+	"os"
+	"unsafe"
+
+	"github.com/gotk3/gotk3/gdk"
+
+	"github.com/gotk3/gotk3/glib"
+)
+
+// TestFindLabel is a wrapper around gtk_test_find_label().
+// This function will search widget and all its descendants for a GtkLabel widget with a text string matching label_pattern.
+// The labelPattern may contain asterisks “*” and question marks “?” as placeholders, g_pattern_match() is used for the matching.
+func TestFindLabel(widget IWidget, labelPattern string) (IWidget, error) {
+	cstr := C.CString(labelPattern)
+	defer C.free(unsafe.Pointer(cstr))
+	c := C.gtk_test_find_label(widget.toWidget(), (*C.gchar)(cstr))
+	if c == nil {
+		return nil, errors.New("no label with pattern '" + labelPattern + "' found")
+	}
+	obj, err := castWidget(c)
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+// TestFindSibling is a wrapper around gtk_test_find_sibling().
+// This function will search siblings of base_widget and siblings of its ancestors for all widgets matching widgetType.
+// Of the matching widgets, the one that is geometrically closest to base_widget will be returned.
+func TestFindSibling(baseWidget IWidget, widgetType glib.Type) (IWidget, error) {
+	c := C.gtk_test_find_sibling(baseWidget.toWidget(), C.GType(widgetType))
+	if c == nil {
+		return nil, errors.New("no widget of type '" + widgetType.Name() + "' found")
+	}
+	obj, err := castWidget(c)
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+// TestFindWidget is a wrapper around gtk_test_find_widget().
+// This function will search the descendants of widget for a widget of type widget_type that has a label matching labelPattern next to it.
+// This is most useful for automated GUI testing, e.g. to find the “OK” button in a dialog and synthesize clicks on it.
+// However see TestFindLabel(), TestFindSibling() and TestWidgetClick() (and their GTK documentation)
+// for possible caveats involving the search of such widgets and synthesizing widget events.
+func TestFindWidget(widget IWidget, labelPattern string, widgetType glib.Type) (IWidget, error) {
+	cstr := C.CString(labelPattern)
+	defer C.free(unsafe.Pointer(cstr))
+	c := C.gtk_test_find_widget(widget.toWidget(), (*C.gchar)(cstr), C.GType(widgetType))
+	if c == nil {
+		return nil, errors.New("no widget with label pattern '" + labelPattern + "' and type '" + widgetType.Name() + "' found")
+	}
+	obj, err := castWidget(c)
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+
+/*
+TestInit is a wrapper around gtk_test_init().
+This function is used to initialize a GTK+ test program.
+It will in turn call g_test_init() and gtk_init() to properly initialize the testing framework and graphical toolkit.
+It’ll also set the program’s locale to “C” and prevent loading of rc files and Gtk+ modules.
+This is done to make tets program environments as deterministic as possible.
+
+Like gtk_init() and g_test_init(), any known arguments will be processed and stripped from argc and argv.
+*/
+func TestInit(args *[]string) {
+	if args != nil {
+		argc := C.int(len(*args))
+		argv := C.make_strings(argc)
+		defer C.destroy_strings(argv)
+
+		for i, arg := range *args {
+			cstr := C.CString(arg)
+			C.set_string(argv, C.int(i), (*C.gchar)(cstr))
+		}
+
+		C._gtk_test_init((*C.int)(unsafe.Pointer(&argc)),
+			(***C.char)(unsafe.Pointer(&argv)))
+
+		unhandled := make([]string, argc)
+		for i := 0; i < int(argc); i++ {
+			cstr := C.get_string(argv, C.int(i))
+			unhandled[i] = goString(cstr)
+			C.free(unsafe.Pointer(cstr))
+		}
+		*args = unhandled
+	} else {
+		// gtk_test_init does not take nil, we have to use an empty argument list
+		// (only containing the first arg, which is the executable name)
+		argc := C.int(1)
+		argv := C.make_strings(argc)
+		defer C.destroy_strings(argv)
+
+		// Add first argument
+		cstr := C.CString(os.Args[0])
+		C.set_string(argv, C.int(0), (*C.gchar)(cstr))
+
+		C._gtk_test_init((*C.int)(unsafe.Pointer(&argc)),
+			(***C.char)(unsafe.Pointer(&argv)))
+	}
+}
+
+// TestListAllTypes is a wrapper around gtk_test_list_all_types().
+// Return the type ids that have been registered after calling TestRegisterAllTypes().
+func TestListAllTypes() []glib.Type {
+	var types *C.GType
+	var clen C.guint
+
+	types = C.gtk_test_list_all_types(&clen)
+	defer C.free(unsafe.Pointer(types))
+
+	length := uint(clen)
+
+	typeReturn := make([]glib.Type, length)
+	for i := uint(0); i < length; i++ {
+		current := (*C.GType)(pointerAtOffset(unsafe.Pointer(types), unsafe.Sizeof(*types), i))
+		typeReturn[i] = glib.Type(*current)
+	}
+	return typeReturn
+}
+
+// pointerAtOffset adjusts `arrayPointer` (pointer to the first element of a C array)
+// to point at the offset `i`,
+// to be able to read the value there without having to go through cgo.
+func pointerAtOffset(arrayPointer unsafe.Pointer, elementSize uintptr, offset uint) unsafe.Pointer {
+	return unsafe.Pointer(uintptr(arrayPointer) + elementSize*uintptr(offset))
+}
+
+// TestRegisterAllTypes is a wrapper around gtk_test_register_all_types().
+// Force registration of all core Gtk+ and Gdk object types.
+// This allowes to refer to any of those object types via g_type_from_name() after calling this function.
+func TestRegisterAllTypes() {
+	C.gtk_test_register_all_types()
+}
+
+// TestWidgetSendKey is a wrapper around gtk_test_widget_send_key()
+//
+// This function will generate keyboard press and release events
+// in the middle of the first GdkWindow found that belongs to widget.
+// For windowless widgets like GtkButton (which returns FALSE from gtk_widget_get_has_window()),
+// this will often be an input-only event window.
+// For other widgets, this is usually widget->window.
+//
+// widget: Widget to generate a key press and release on.
+// keyval: A Gdk keyboard value.
+// modifiers: Keyboard modifiers the event is setup with.
+//
+// returns: whether all actions neccessary for the key event simulation were carried out successfully.
+func TestWidgetSendKey(widget IWidget, keyval uint, modifiers gdk.ModifierType) bool {
+	return gobool(C.gtk_test_widget_send_key(widget.toWidget(), C.guint(keyval), C.GdkModifierType(modifiers)))
+}

--- a/gtk/testing_deprecated_since_3_20.go
+++ b/gtk/testing_deprecated_since_3_20.go
@@ -1,0 +1,63 @@
+//+build gtk_3_6 gtk_3_8 gtk_3_10 gtk_3_12 gtk_3_14 gtk_3_16 gtk_3_18
+
+package gtk
+
+// #include <gtk/gtk.h>
+import "C"
+import (
+	"github.com/gotk3/gotk3/gdk"
+)
+
+
+/*
+GtkWidget *
+gtk_test_create_simple_window (const gchar *window_title,
+							   const gchar *dialog_text);
+
+GtkWidget *
+gtk_test_create_widget (GType widget_type,
+                        const gchar *first_property_name,
+						...);
+
+GtkWidget *
+gtk_test_display_button_window (const gchar *window_title,
+                                const gchar *dialog_text,
+								...);
+
+double
+gtk_test_slider_get_value (GtkWidget *widget);
+
+void
+gtk_test_slider_set_perc (GtkWidget *widget,
+						  double percentage);
+
+gboolean
+gtk_test_spin_button_click (GtkSpinButton *spinner,
+                            guint button,
+							gboolean upwards);
+
+gchar *
+gtk_test_text_get (GtkWidget *widget);
+
+void
+gtk_test_text_set (GtkWidget *widget,
+				   const gchar *string);
+*/
+
+// TestWidgetClick is a wrapper around gtk_test_widget_click()
+// Deprecated since 3.20
+//
+// This function will generate a button click (button press and button release event)
+// in the middle of the first GdkWindow found that belongs to widget.
+// For windowless widgets like GtkButton (which returns FALSE from gtk_widget_get_has_window()),
+// this will often be an input-only event window.
+// For other widgets, this is usually widget->window.
+//
+// widget: Widget to generate a button click on.
+// button: Number of the pointer button for the event, usually 1, 2 or 3.
+// modifiers: Keyboard modifiers the event is setup with.
+//
+// returns: whether all actions neccessary for the button click simulation were carried out successfully.
+func TestWidgetClick(widget IWidget, button uint, modifiers gdk.ModifierType) bool {
+	return gobool(C.gtk_test_widget_click(widget.toWidget(), C.guint(button), C.GdkModifierType(modifiers)))
+}

--- a/gtk/testing_since_3_10.go
+++ b/gtk/testing_since_3_10.go
@@ -1,0 +1,13 @@
+// +build !gtk_3_6,!gtk_3_8
+
+package gtk
+
+// #include <gtk/gtk.h>
+import "C"
+
+// TestWidgetWaitForDraw is a wrapper around gtk_test_widget_wait_for_draw().
+// Enters the main loop and waits for widget to be “drawn”. In this context that means it waits for the frame clock of widget to have run a full styling, layout and drawing cycle.
+// This function is intended to be used for syncing with actions that depend on widget relayouting or on interaction with the display server.
+func TestWidgetWaitForDraw(widget IWidget) {
+	C.gtk_test_widget_wait_for_draw(widget.toWidget())
+}

--- a/gtk/testing_test.go
+++ b/gtk/testing_test.go
@@ -1,0 +1,125 @@
+package gtk
+
+import (
+	"reflect"
+	"testing"
+	"unsafe"
+
+	"github.com/gotk3/gotk3/glib"
+)
+
+func TestTestRegisterAllTypes(t *testing.T) {
+	TestRegisterAllTypes()
+	types := TestListAllTypes()
+
+	if len(types) == 0 {
+		t.Error("Expected at least one type to be registered")
+	}
+}
+
+func TestPointerAtOffset(t *testing.T) {
+	// Simulate a C array by using a pointer to the first element
+	intArray := []int{4, 8, 2, 5, 9}
+	arrayPointer := unsafe.Pointer(&intArray[0])
+	elementSize := unsafe.Sizeof(intArray[0])
+
+	for i, val := range intArray {
+		intAtOffset := (*int)(pointerAtOffset(arrayPointer, elementSize, uint(i)))
+		if val != *intAtOffset {
+			t.Errorf("Expected %d at offset %d, got %d", val, i, *intAtOffset)
+		}
+	}
+}
+
+func TestTestFindLabel(t *testing.T) {
+	// Build a dummy widget
+	box, _ := BoxNew(ORIENTATION_HORIZONTAL, 0)
+	label1, _ := LabelNew("First")
+	label2, _ := LabelNew("Second")
+
+	box.PackStart(label1, true, true, 0)
+	box.PackStart(label2, true, true, 0)
+
+	// Find a label in the box with text matching Fir*
+	found, err := TestFindLabel(box, "Fir*")
+	if err != nil {
+		t.Error("Unexpected error:", err.Error())
+	}
+
+	// Should return the label1
+	if found == nil {
+		t.Error("Return value is nil")
+	}
+	foundAsLabel, ok := found.(*Label)
+	if !ok {
+		t.Error("Did not return a label. Received type:", reflect.TypeOf(found))
+	}
+
+	text, _ := foundAsLabel.GetText()
+	if text != "First" {
+		t.Error("Expected: First, Got:", text)
+	}
+
+}
+
+func TestTestFindSibling(t *testing.T) {
+	// Build a dummy widget
+	box, _ := BoxNew(ORIENTATION_HORIZONTAL, 0)
+	label1, _ := LabelNew("First")
+	label2, _ := LabelNew("Second")
+
+	box.PackStart(label1, true, true, 0)
+	box.PackStart(label2, true, true, 0)
+
+	// Finx a sibling to label1, of type label
+	found, err := TestFindSibling(label1, glib.TypeFromName("GtkLabel"))
+	if err != nil {
+		t.Error("Unexpected error:", err.Error())
+	}
+
+	// Should return the label2
+	if found == nil {
+		t.Error("Return value is nil")
+	}
+	foundAsLabel, ok := found.(*Label)
+	if !ok {
+		t.Error("Did not return a label. Received type:", reflect.TypeOf(found))
+	}
+
+	text, _ := foundAsLabel.GetText()
+	if text != "Second" {
+		t.Error("Expected: First, Got:", text)
+	}
+
+}
+
+func TestTestFindWidget(t *testing.T) {
+	// Build a dummy widget
+	box, _ := BoxNew(ORIENTATION_HORIZONTAL, 0)
+	button1, _ := ButtonNewWithLabel("First")
+	button2, _ := ButtonNewWithLabel("Second")
+
+	box.PackStart(button1, true, true, 0)
+	box.PackStart(button2, true, true, 0)
+
+	// Find a label in the box with text matching Fir*
+	found, err := TestFindWidget(box, "Sec*", glib.TypeFromName("GtkButton"))
+	if err != nil {
+		t.Error("Unexpected error:", err.Error())
+	}
+
+	// Should return the button2
+	if found == nil {
+		t.Error("Return value is nil")
+	}
+	foundAsButton, ok := found.(*Button)
+	if !ok {
+		t.Error("Did not return a button. Received type:", reflect.TypeOf(found))
+	}
+
+	text, _ := foundAsButton.GetLabel()
+	if text != "Second" {
+		t.Error("Expected: Second, Got:", text)
+	}
+
+}

--- a/gtk/window.go
+++ b/gtk/window.go
@@ -8,6 +8,7 @@ package gtk
 import "C"
 import (
 	"errors"
+	"runtime"
 	"unsafe"
 
 	"github.com/gotk3/gotk3/gdk"
@@ -610,13 +611,26 @@ func (v *Window) SetMnemonicModifier(mods gdk.ModifierType) {
 	C.gtk_window_set_mnemonic_modifier(v.native(), C.GdkModifierType(mods))
 }
 
+// WindowListToplevels is a wrapper around gtk_window_list_toplevels().
+// Returned list is wrapped to return *gtk.Window elements.
+func WindowListToplevels() *glib.List {
+	glist := C.gtk_window_list_toplevels()
+	list := glib.WrapList(uintptr(unsafe.Pointer(glist)))
+	list.DataWrapper(func(ptr unsafe.Pointer) interface{} {
+		return wrapWindow(glib.Take(ptr))
+	})
+	runtime.SetFinalizer(list, func(l *glib.List) {
+		l.Free()
+	})
+	return list
+}
+
 // TODO gtk_window_begin_move_drag().
 // TODO gtk_window_begin_resize_drag().
 // TODO gtk_window_get_default_icon_list().
 // TODO gtk_window_get_group().
 // TODO gtk_window_get_icon_list().
 // TODO gtk_window_get_window_type().
-// TODO gtk_window_list_toplevels().
 // TODO gtk_window_propagate_key_event().
 // TODO gtk_window_set_default_icon_list().
 // TODO gtk_window_set_icon_list().

--- a/gtk/window_since_3_14.go
+++ b/gtk/window_since_3_14.go
@@ -1,0 +1,11 @@
+// +build !gtk_3_6,!gtk_3_8,!gtk_3_10,!gtk_3_12
+
+package gtk
+
+// #include <gtk/gtk.h>
+import "C"
+
+// SetInteractiveDebugging is a wrapper around gtk_window_set_interactive_debugging().
+func SetInteractiveDebugging(enable bool) {
+	C.gtk_window_set_interactive_debugging(gbool(enable))
+}


### PR DESCRIPTION
* gtk_test_find_label + unit test
* gtk_test_find_sibling + unit test
* gtk_test_find_widget + unit test
* gtk_test_init
* gtk_test_list_all_types + unit test
* gtk_test_register_all_types + unit test
* gtk_test_widget_send_key

* gdk_test_render_sync
* gdk_test_simulate_button
* gdk_test_simulate_key

* gtk_window_set_interactive_debugging
* gtk_window_list_toplevels

* g_type_is_a + unit test
* g_type_from_name + unit test
* g_type_next_base + unit test

Since 3.10:
* gtk_test_widget_wait_for_draw

Deprecated since 3.20:
* gtk_test_widget_click