### PR TITLE
Add gtk_deprecated build tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,10 +189,21 @@ http://localhost:6060/pkg/github.com/gotk3/gotk3
 
 ## Installation
 
-gotk3 currently requires GTK 3.6-3.22, GLib 2.36-2.40, and
+gotk3 currently requires GTK 3.6-3.24, GLib 2.36-2.40, and
 Cairo 1.10 or 1.12.  A recent Go (1.8 or newer) is also required.
 
 For detailed instructions see the wiki pages: [installation](https://github.com/gotk3/gotk3/wiki#installation)
+
+## Using deprecated features
+
+By default, deprecated GTK features are not included in the build.
+
+By specifying the e.g. build tag `gtk_3_20`, any feature deprecated in GTK 3.20 or earlier will NOT be available.
+To enable deprecated features in the build, add the tag `gtk_deprecated`.
+Example:
+```shell
+$ go build -tags "gtk_3_10 gtk_deprecated" example.go
+```
 
 ## TODO
 

--- a/gdk/gdk_deprecated_since_3_10.go
+++ b/gdk/gdk_deprecated_since_3_10.go
@@ -19,7 +19,7 @@
 // 3.8 or earlier.  To target an earlier build build, use the build tag
 // gtk_MAJOR_MINOR.  For example, to target GTK 3.8, run
 // 'go build -tags gtk_3_8'.
-// +build gtk_3_6 gtk_3_8
+// +build gtk_3_6 gtk_3_8 gtk_deprecated
 
 package gdk
 

--- a/gdk/gdk_deprecated_since_3_16.go
+++ b/gdk/gdk_deprecated_since_3_16.go
@@ -1,4 +1,4 @@
-//+build gtk_3_6 gtk_3_8 gtk_3_10 gtk_3_12 gtk_3_14
+//+build gtk_3_6 gtk_3_8 gtk_3_10 gtk_3_12 gtk_3_14 gtk_deprecated
 
 package gdk
 

--- a/gdk/gdk_deprecated_since_3_20.go
+++ b/gdk/gdk_deprecated_since_3_20.go
@@ -1,4 +1,4 @@
-//+build gtk_3_6 gtk_3_8 gtk_3_10 gtk_3_12 gtk_3_14 gtk_3_16 gtk_3_18
+//+build gtk_3_6 gtk_3_8 gtk_3_10 gtk_3_12 gtk_3_14 gtk_3_16 gtk_3_18 gtk_deprecated
 
 package gdk
 

--- a/gdk/gdk_deprecated_since_3_22.go
+++ b/gdk/gdk_deprecated_since_3_22.go
@@ -1,4 +1,4 @@
-//+build gtk_3_6 gtk_3_8 gtk_3_10 gtk_3_12 gtk_3_14 gtk_3_16 gtk_3_18 gtk_3_20
+//+build gtk_3_6 gtk_3_8 gtk_3_10 gtk_3_12 gtk_3_14 gtk_3_16 gtk_3_18 gtk_3_20 gtk_deprecated
 
 package gdk
 

--- a/gtk/gtk_deprecated_since_3_10.go
+++ b/gtk/gtk_deprecated_since_3_10.go
@@ -19,7 +19,7 @@
 // 3.8 or earlier.  To target an earlier build build, use the build tag
 // gtk_MAJOR_MINOR.  For example, to target GTK 3.8, run
 // 'go build -tags gtk_3_8'.
-// +build gtk_3_6 gtk_3_8
+// +build gtk_3_6 gtk_3_8 gtk_deprecated
 
 package gtk
 

--- a/gtk/gtk_deprecated_since_3_12.go
+++ b/gtk/gtk_deprecated_since_3_12.go
@@ -19,7 +19,7 @@
 // 3.10 or earlier.  To target an earlier build build, use the build tag
 // gtk_MAJOR_MINOR.  For example, to target GTK 3.8, run
 // 'go build -tags gtk_3_8'.
-// +build gtk_3_6 gtk_3_8 gtk_3_10
+// +build gtk_3_6 gtk_3_8 gtk_3_10 gtk_deprecated
 
 package gtk
 

--- a/gtk/gtk_deprecated_since_3_14.go
+++ b/gtk/gtk_deprecated_since_3_14.go
@@ -1,4 +1,4 @@
-// +build gtk_3_6 gtk_3_8 gtk_3_10 gtk_3_12
+// +build gtk_3_6 gtk_3_8 gtk_3_10 gtk_3_12 gtk_deprecated
 
 package gtk
 

--- a/gtk/gtk_deprecated_since_3_16.go
+++ b/gtk/gtk_deprecated_since_3_16.go
@@ -1,4 +1,4 @@
-//+build gtk_3_6 gtk_3_8 gtk_3_10 gtk_3_12 gtk_3_14
+//+build gtk_3_6 gtk_3_8 gtk_3_10 gtk_3_12 gtk_3_14 gtk_deprecated
 
 package gtk
 

--- a/gtk/gtk_deprecated_since_3_18.go
+++ b/gtk/gtk_deprecated_since_3_18.go
@@ -1,4 +1,4 @@
-//+build gtk_3_6 gtk_3_8 gtk_3_10 gtk_3_12 gtk_3_14 gtk_3_16
+//+build gtk_3_6 gtk_3_8 gtk_3_10 gtk_3_12 gtk_3_14 gtk_3_16 gtk_deprecated
 
 package gtk
 

--- a/gtk/gtk_deprecated_since_3_20.go
+++ b/gtk/gtk_deprecated_since_3_20.go
@@ -1,4 +1,4 @@
-//+build gtk_3_6 gtk_3_8 gtk_3_10 gtk_3_12 gtk_3_14 gtk_3_16 gtk_3_18
+//+build gtk_3_6 gtk_3_8 gtk_3_10 gtk_3_12 gtk_3_14 gtk_3_16 gtk_3_18 gtk_deprecated
 
 package gtk
 

--- a/gtk/gtk_deprecated_since_3_22.go
+++ b/gtk/gtk_deprecated_since_3_22.go
@@ -1,4 +1,4 @@
-//+build gtk_3_6 gtk_3_8 gtk_3_10 gtk_3_12 gtk_3_14 gtk_3_16 gtk_3_18 gtk_3_20
+//+build gtk_3_6 gtk_3_8 gtk_3_10 gtk_3_12 gtk_3_14 gtk_3_16 gtk_3_18 gtk_3_20 gtk_deprecated
 
 package gtk
 

--- a/gtk/gtk_deprecated_since_3_24.go
+++ b/gtk/gtk_deprecated_since_3_24.go
@@ -1,4 +1,4 @@
-//+build gtk_3_6 gtk_3_8 gtk_3_10 gtk_3_12 gtk_3_14 gtk_3_16 gtk_3_18 gtk_3_20 gtk_3_22
+//+build gtk_3_6 gtk_3_8 gtk_3_10 gtk_3_12 gtk_3_14 gtk_3_16 gtk_3_18 gtk_3_20 gtk_3_22 gtk_deprecated
 
 package gtk
 

--- a/gtk/gtk_deprecated_since_3_8.go
+++ b/gtk/gtk_deprecated_since_3_8.go
@@ -19,7 +19,7 @@
 // 3.6 or earlier.  To target an earlier build build, use the build tag
 // gtk_MAJOR_MINOR.  For example, to target GTK 3.6, run
 // 'go build -tags gtk_3_6'.
-// +build gtk_3_6
+// +build gtk_3_6 gtk_deprecated
 
 package gtk
 

--- a/gtk/testing_deprecated_since_3_20.go
+++ b/gtk/testing_deprecated_since_3_20.go
@@ -1,4 +1,4 @@
-//+build gtk_3_6 gtk_3_8 gtk_3_10 gtk_3_12 gtk_3_14 gtk_3_16 gtk_3_18
+//+build gtk_3_6 gtk_3_8 gtk_3_10 gtk_3_12 gtk_3_14 gtk_3_16 gtk_3_18 gtk_deprecated
 
 package gtk
 
@@ -7,7 +7,6 @@ import "C"
 import (
 	"github.com/gotk3/gotk3/gdk"
 )
-
 
 /*
 GtkWidget *


### PR DESCRIPTION
Optionally includes deprecated features in builds

See added documentation in the readme file how to use this. Please review & comment!  
This is a straightforward change, but could have bad consequences if I missed anything.

@MJacred you have a special case with issue gotk3/gotk3#516. Read this to see how to adjust your build tags accordingly.

Fixes gotk3/gotk3#253  
Closes gotk3/gotk3#475

Technical documentation, should be moved to the wiki if there are no objections to this change.
```go
// Package main is an example-user of gotk3
package main

import "github.com/gotk3/gotk3/gtk"

func main() {
	gtk.dep_since_3_20()
	gtk.since_3_16()
}
```

```go
// Filename: *_deprecated_since_3_20.go
// This file is compiled for all GTK versions below 3.20, and optionally with gtk_deprecated
// +build gtk_3_6 gtk_3_8 gtk_3_10 gtk_3_12 gtk_3_14 gtk_3_16 gtk_3_18 gtk_deprecated

package gtk

func dep_since_3_20() {
	println("< 3.20")
}

```

```go
// Filename: *_since_3_16_deprecated_since_3_20.go
// This file is normally only compiled for GTK 3.16 and 3.18.
// Adding gtk_deprecated MUST NOT compile this file for GTK<=3.14,
// which requires a combined constraint "!gtk_3_6,!gtk_3_8,!gtk_3_10,!gtk_3_12,!gtk_3_14,gtk_deprecated"
// to specifically exclude all versions of GTK where this was NOT available.
// Do not add spaces in that constraint, only commas!
// +build !gtk_3_6,!gtk_3_8,!gtk_3_10,!gtk_3_12,!gtk_3_14,gtk_deprecated gtk_3_16 gtk_3_18

package main

func since_3_16() {
	println(">= 3.16, < 3_20")
}
```

Result:
```shell
go build -tags "gtk_3_22 gtk_deprecated"
```
will compile both files, but
```shell
go build -tags "gtk_3_14 gtk_deprecated"
```
will only compile the first.