### PR TITLE
Clean up cgo callbacks

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -522,7 +522,7 @@ const (
 
 // TODO:
 // GTK_INPUT_HINT_VERTICAL_WRITING Since 3.18
-// GTK_INPUT_HINT_EMOJI Since 3.22.20	 
+// GTK_INPUT_HINT_EMOJI Since 3.22.20
 // GTK_INPUT_HINT_NO_EMOJI Since 3.22.20
 
 func marshalInputHints(p uintptr) (interface{}, error) {
@@ -9862,10 +9862,9 @@ type TreeIterCompareFunc func(model *TreeModel, a, b *TreeIter, userData interfa
 
 // GetSortColumnId() is a wrapper around gtk_tree_sortable_get_sort_column_id().
 func (v *TreeSortable) GetSortColumnId() (int, SortType, bool) {
-	sort := C.toGtkTreeSortable(unsafe.Pointer(v.native()))
 	var column C.gint
 	var order C.GtkSortType
-	ok := gobool(C.gtk_tree_sortable_get_sort_column_id(sort, &column, &order))
+	ok := gobool(C.gtk_tree_sortable_get_sort_column_id(v.native(), &column, &order))
 	return int(column), SortType(order), ok
 }
 
@@ -9887,8 +9886,7 @@ var (
 
 // SetSortColumnId() is a wrapper around gtk_tree_sortable_set_sort_column_id().
 func (v *TreeSortable) SetSortColumnId(column int, order SortType) {
-	sort := C.toGtkTreeSortable(unsafe.Pointer(v.native()))
-	C.gtk_tree_sortable_set_sort_column_id(sort, C.gint(column), C.GtkSortType(order))
+	C.gtk_tree_sortable_set_sort_column_id(v.native(), C.gint(column), C.GtkSortType(order))
 }
 
 // SetSortFunc() is a wrapper around gtk_tree_sortable_set_sort_func().

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -9300,6 +9300,11 @@ func (v *TreeModel) ForEach(f TreeModelForeachFunc, userData ...interface{}) {
 	treeModelForeachFuncRegistry.Unlock()
 
 	C._gtk_tree_model_foreach(v.toTreeModel(), C.gpointer(uintptr(id)))
+
+	// Clean up callback immediately as we only need it for the duration of this Foreach call
+	treeModelForeachFuncRegistry.Lock()
+	delete(treeModelForeachFuncRegistry.m, id)
+	treeModelForeachFuncRegistry.Unlock()
 }
 
 /*
@@ -9410,6 +9415,7 @@ var (
 
 // SetVisibleFunc is a wrapper around gtk_tree_model_filter_set_visible_func().
 func (v *TreeModelFilter) SetVisibleFunc(f TreeModelFilterVisibleFunc, userData ...interface{}) {
+	// TODO: figure out a way to determine when we can clean up
 	treeModelVisibleFilterFuncRegistry.Lock()
 	id := treeModelVisibleFilterFuncRegistry.next
 	treeModelVisibleFilterFuncRegistry.next++
@@ -9725,6 +9731,11 @@ func (v *TreeSelection) SelectedForEach(f TreeSelectionForeachFunc, userData ...
 	treeSelectionForeachFuncRegistry.Unlock()
 
 	C._gtk_tree_selection_selected_foreach(v.native(), C.gpointer(uintptr(id)))
+
+	// Clean up callback immediately as we only need it for the duration of this Foreach call
+	treeSelectionForeachFuncRegistry.Lock()
+	delete(treeSelectionForeachFuncRegistry.m, id)
+	treeSelectionForeachFuncRegistry.Unlock()
 }
 
 /*
@@ -9863,6 +9874,7 @@ func (v *TreeSortable) SetSortColumnId(column int, order SortType) {
 
 // SetSortFunc() is a wrapper around gtk_tree_sortable_set_sort_func().
 func (v *TreeSortable) SetSortFunc(sortColumn int, f TreeIterCompareFunc, userData ...interface{}) {
+	// TODO: figure out a way to determine when we can clean up
 	treeStoreSortFuncRegistry.Lock()
 	id := treeStoreSortFuncRegistry.next
 	treeStoreSortFuncRegistry.next++
@@ -9874,6 +9886,7 @@ func (v *TreeSortable) SetSortFunc(sortColumn int, f TreeIterCompareFunc, userDa
 
 // SetDefaultSortFunc() is a wrapper around gtk_tree_sortable_set_default_sort_func().
 func (v *TreeSortable) SetDefaultSortFunc(f TreeIterCompareFunc, userData ...interface{}) {
+	// TODO: figure out a way to determine when we can clean up
 	treeStoreSortFuncRegistry.Lock()
 	id := treeStoreSortFuncRegistry.next
 	treeStoreSortFuncRegistry.next++

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -7294,7 +7294,6 @@ func (v *ScrolledWindow) SetVAdjustment(adjustment *Adjustment) {
 // gtk_scrolled_window_set_placement().
 // gtk_scrolled_window_unset_placement().
 
-
 // GetShadowType is a wrapper around gtk_scrolled_window_get_shadow_type().
 func (v *ScrolledWindow) GetShadowType() ShadowType {
 	c := C.gtk_scrolled_window_get_shadow_type(v.native())
@@ -9274,11 +9273,11 @@ func (v *TreeModel) FilterNew(root *TreePath) (*TreeModelFilter, error) {
 
 // TreeModelForeachFunc defines the function prototype for the foreach function (f arg) for
 // (* TreeModel).ForEach
-type TreeModelForeachFunc func(model *TreeModel, path *TreePath, iter *TreeIter, userData interface{}) bool
+type TreeModelForeachFunc func(model *TreeModel, path *TreePath, iter *TreeIter, userData ...interface{}) bool
 
 type treeModelForeachFuncData struct {
 	fn       TreeModelForeachFunc
-	userData interface{}
+	userData []interface{}
 }
 
 var (
@@ -9293,23 +9292,14 @@ var (
 )
 
 // ForEach() is a wrapper around gtk_tree_model_foreach ()
-func (v *TreeModel) ForEach(f TreeModelForeachFunc, userData ...interface{}) error {
-	if len(userData) > 1 {
-		return errors.New("userData len must be 0 or 1")
-	}
-
-	t := treeModelForeachFuncData{fn: f}
-	if len(userData) > 0 {
-		t.userData = userData[0]
-	}
+func (v *TreeModel) ForEach(f TreeModelForeachFunc, userData ...interface{}) {
 	treeModelForeachFuncRegistry.Lock()
 	id := treeModelForeachFuncRegistry.next
 	treeModelForeachFuncRegistry.next++
-	treeModelForeachFuncRegistry.m[id] = t
+	treeModelForeachFuncRegistry.m[id] = treeModelForeachFuncData{fn: f, userData: userData}
 	treeModelForeachFuncRegistry.Unlock()
 
 	C._gtk_tree_model_foreach(v.toTreeModel(), C.gpointer(uintptr(id)))
-	return nil
 }
 
 /*
@@ -9400,11 +9390,11 @@ func (v *TreeModelFilter) Refilter() {
 
 // TreeModelFilterVisibleFunc defines the function prototype for the filter visibility function (f arg)
 // to TreeModelFilter.SetVisibleFunc.
-type TreeModelFilterVisibleFunc func(model *TreeModelFilter, iter *TreeIter, userData interface{}) bool
+type TreeModelFilterVisibleFunc func(model *TreeModelFilter, iter *TreeIter, userData ...interface{}) bool
 
 type treeModelFilterVisibleFuncData struct {
 	fn       TreeModelFilterVisibleFunc
-	userData interface{}
+	userData []interface{}
 }
 
 var (
@@ -9419,23 +9409,14 @@ var (
 )
 
 // SetVisibleFunc is a wrapper around gtk_tree_model_filter_set_visible_func().
-func (v *TreeModelFilter) SetVisibleFunc(f TreeModelFilterVisibleFunc, userData ...interface{}) error {
-	if len(userData) > 1 {
-		return errors.New("userData len must be 0 or 1")
-	}
-
-	t := treeModelFilterVisibleFuncData{fn: f}
-	if len(userData) > 0 {
-		t.userData = userData[0]
-	}
+func (v *TreeModelFilter) SetVisibleFunc(f TreeModelFilterVisibleFunc, userData ...interface{}) {
 	treeModelVisibleFilterFuncRegistry.Lock()
 	id := treeModelVisibleFilterFuncRegistry.next
 	treeModelVisibleFilterFuncRegistry.next++
-	treeModelVisibleFilterFuncRegistry.m[id] = t
+	treeModelVisibleFilterFuncRegistry.m[id] = treeModelFilterVisibleFuncData{fn: f, userData: userData}
 	treeModelVisibleFilterFuncRegistry.Unlock()
 
 	C._gtk_tree_model_filter_set_visible_func(v.native(), C.gpointer(uintptr(id)))
-	return nil
 }
 
 // Down() is a wrapper around gtk_tree_path_down()
@@ -9717,11 +9698,11 @@ func (v *TreeSelection) PathIsSelected(path *TreePath) bool {
 
 // TreeSelectionForeachFunc defines the function prototype for the selected_foreach function (f arg) for
 // (* TreeSelection).SelectedForEach
-type TreeSelectionForeachFunc func(model *TreeModel, path *TreePath, iter *TreeIter, userData interface{})
+type TreeSelectionForeachFunc func(model *TreeModel, path *TreePath, iter *TreeIter, userData ...interface{})
 
 type treeSelectionForeachFuncData struct {
 	fn       TreeSelectionForeachFunc
-	userData interface{}
+	userData []interface{}
 }
 
 var (
@@ -9736,23 +9717,14 @@ var (
 )
 
 // SelectedForEach() is a wrapper around gtk_tree_selection_selected_foreach()
-func (v *TreeSelection) SelectedForEach(f TreeSelectionForeachFunc, userData ...interface{}) error {
-	if len(userData) > 1 {
-		return errors.New("userData len must be 0 or 1")
-	}
-
-	t := treeSelectionForeachFuncData{fn: f}
-	if len(userData) > 0 {
-		t.userData = userData[0]
-	}
+func (v *TreeSelection) SelectedForEach(f TreeSelectionForeachFunc, userData ...interface{}) {
 	treeSelectionForeachFuncRegistry.Lock()
 	id := treeSelectionForeachFuncRegistry.next
 	treeSelectionForeachFuncRegistry.next++
-	treeSelectionForeachFuncRegistry.m[id] = t
+	treeSelectionForeachFuncRegistry.m[id] = treeSelectionForeachFuncData{fn: f, userData: userData}
 	treeSelectionForeachFuncRegistry.Unlock()
 
 	C._gtk_tree_selection_selected_foreach(v.native(), C.gpointer(uintptr(id)))
-	return nil
 }
 
 /*
@@ -9858,7 +9830,7 @@ func wrapTreeSortable(obj *glib.Object) *TreeSortable {
 
 // TreeIterCompareFunc defines the function prototype for the sort function (f arg) for
 // (* TreeSortable).SetSortFunc
-type TreeIterCompareFunc func(model *TreeModel, a, b *TreeIter, userData interface{}) int
+type TreeIterCompareFunc func(model *TreeModel, a, b *TreeIter, userData ...interface{}) int
 
 // GetSortColumnId() is a wrapper around gtk_tree_sortable_get_sort_column_id().
 func (v *TreeSortable) GetSortColumnId() (int, SortType, bool) {
@@ -9870,7 +9842,7 @@ func (v *TreeSortable) GetSortColumnId() (int, SortType, bool) {
 
 type treeStoreSortFuncData struct {
 	fn       TreeIterCompareFunc
-	userData interface{}
+	userData []interface{}
 }
 
 var (
@@ -9890,43 +9862,25 @@ func (v *TreeSortable) SetSortColumnId(column int, order SortType) {
 }
 
 // SetSortFunc() is a wrapper around gtk_tree_sortable_set_sort_func().
-func (v *TreeSortable) SetSortFunc(sortColumn int, f TreeIterCompareFunc, userData ...interface{}) error {
-	if len(userData) > 1 {
-		return errors.New("userData len must be 0 or 1")
-	}
-
-	t := treeStoreSortFuncData{fn: f}
-	if len(userData) > 0 {
-		t.userData = userData[0]
-	}
+func (v *TreeSortable) SetSortFunc(sortColumn int, f TreeIterCompareFunc, userData ...interface{}) {
 	treeStoreSortFuncRegistry.Lock()
 	id := treeStoreSortFuncRegistry.next
 	treeStoreSortFuncRegistry.next++
-	treeStoreSortFuncRegistry.m[id] = t
+	treeStoreSortFuncRegistry.m[id] = treeStoreSortFuncData{fn: f, userData: userData}
 	treeStoreSortFuncRegistry.Unlock()
 
 	C._gtk_tree_sortable_set_sort_func(v.native(), C.gint(sortColumn), C.gpointer(uintptr(id)))
-	return nil
 }
 
 // SetDefaultSortFunc() is a wrapper around gtk_tree_sortable_set_default_sort_func().
-func (v *TreeSortable) SetDefaultSortFunc(f TreeIterCompareFunc, userData ...interface{}) error {
-	if len(userData) > 1 {
-		return errors.New("userData len must be 0 or 1")
-	}
-
-	t := treeStoreSortFuncData{fn: f}
-	if len(userData) > 0 {
-		t.userData = userData[0]
-	}
+func (v *TreeSortable) SetDefaultSortFunc(f TreeIterCompareFunc, userData ...interface{}) {
 	treeStoreSortFuncRegistry.Lock()
 	id := treeStoreSortFuncRegistry.next
 	treeStoreSortFuncRegistry.next++
-	treeStoreSortFuncRegistry.m[id] = t
+	treeStoreSortFuncRegistry.m[id] = treeStoreSortFuncData{fn: f, userData: userData}
 	treeStoreSortFuncRegistry.Unlock()
 
 	C._gtk_tree_sortable_set_default_sort_func(v.native(), C.gpointer(uintptr(id)))
-	return nil
 }
 
 func (v *TreeSortable) HasDefaultSortFunc() bool {
@@ -10518,4 +10472,3 @@ func castWidget(c *C.GtkWidget) (IWidget, error) {
 
 	return ret, nil
 }
-

--- a/gtk/gtk_export.go
+++ b/gtk/gtk_export.go
@@ -78,6 +78,7 @@ func goPageSetupDone(setup *C.GtkPageSetup,
 
 	pageSetupDoneCallbackRegistry.Lock()
 	r := pageSetupDoneCallbackRegistry.m[id]
+	// This callback is only used once, so we can clean up immediately
 	delete(pageSetupDoneCallbackRegistry.m, id)
 	pageSetupDoneCallbackRegistry.Unlock()
 
@@ -93,11 +94,11 @@ func goPrintSettings(key *C.gchar,
 
 	id := int(uintptr(userData))
 
-	printSettingsCallbackRegistry.Lock()
+	printSettingsCallbackRegistry.RLock()
 	r := printSettingsCallbackRegistry.m[id]
 	// TODO: figure out a way to determine when we can clean up
 	//delete(printSettingsCallbackRegistry.m, id)
-	printSettingsCallbackRegistry.Unlock()
+	printSettingsCallbackRegistry.RUnlock()
 
 	r.fn(C.GoString((*C.char)(key)), C.GoString((*C.char)(value)), r.userData)
 
@@ -107,9 +108,9 @@ func goPrintSettings(key *C.gchar,
 func goTreeModelFilterFuncs(filter *C.GtkTreeModelFilter, iter *C.GtkTreeIter, data C.gpointer) C.gboolean {
 	id := int(uintptr(data))
 
-	treeModelVisibleFilterFuncRegistry.Lock()
+	treeModelVisibleFilterFuncRegistry.RLock()
 	r := treeModelVisibleFilterFuncRegistry.m[id]
-	treeModelVisibleFilterFuncRegistry.Unlock()
+	treeModelVisibleFilterFuncRegistry.RUnlock()
 
 	goIter := &TreeIter{(C.GtkTreeIter)(*iter)}
 	return gbool(r.fn(
@@ -122,9 +123,9 @@ func goTreeModelFilterFuncs(filter *C.GtkTreeModelFilter, iter *C.GtkTreeIter, d
 func goTreeSortableSortFuncs(model *C.GtkTreeModel, a, b *C.GtkTreeIter, data C.gpointer) C.gint {
 	id := int(uintptr(data))
 
-	treeStoreSortFuncRegistry.Lock()
+	treeStoreSortFuncRegistry.RLock()
 	r := treeStoreSortFuncRegistry.m[id]
-	treeStoreSortFuncRegistry.Unlock()
+	treeStoreSortFuncRegistry.RUnlock()
 
 	goIterA := &TreeIter{(C.GtkTreeIter)(*a)}
 	goIterB := &TreeIter{(C.GtkTreeIter)(*b)}
@@ -136,9 +137,9 @@ func goTreeSortableSortFuncs(model *C.GtkTreeModel, a, b *C.GtkTreeIter, data C.
 func goTreeModelForeachFunc(model *C.GtkTreeModel, path *C.GtkTreePath, iter *C.GtkTreeIter, data C.gpointer) C.gboolean {
 	id := int(uintptr(data))
 
-	treeModelForeachFuncRegistry.Lock()
+	treeModelForeachFuncRegistry.RLock()
 	r := treeModelForeachFuncRegistry.m[id]
-	treeModelForeachFuncRegistry.Unlock()
+	treeModelForeachFuncRegistry.RUnlock()
 
 	goPath := &TreePath{(*C.GtkTreePath)(path)}
 	goIter := &TreeIter{(C.GtkTreeIter)(*iter)}
@@ -153,9 +154,9 @@ func goTreeModelForeachFunc(model *C.GtkTreeModel, path *C.GtkTreePath, iter *C.
 func goTreeSelectionForeachFunc(model *C.GtkTreeModel, path *C.GtkTreePath, iter *C.GtkTreeIter, data C.gpointer) {
 	id := int(uintptr(data))
 
-	treeSelectionForeachFuncRegistry.Lock()
+	treeSelectionForeachFuncRegistry.RLock()
 	r := treeSelectionForeachFuncRegistry.m[id]
-	treeSelectionForeachFuncRegistry.Unlock()
+	treeSelectionForeachFuncRegistry.RUnlock()
 
 	goPath := &TreePath{(*C.GtkTreePath)(path)}
 	goIter := &TreeIter{(C.GtkTreeIter)(*iter)}

--- a/gtk/gtk_export.go
+++ b/gtk/gtk_export.go
@@ -96,8 +96,6 @@ func goPrintSettings(key *C.gchar,
 
 	printSettingsCallbackRegistry.RLock()
 	r := printSettingsCallbackRegistry.m[id]
-	// TODO: figure out a way to determine when we can clean up
-	//delete(printSettingsCallbackRegistry.m, id)
 	printSettingsCallbackRegistry.RUnlock()
 
 	r.fn(C.GoString((*C.char)(key)), C.GoString((*C.char)(value)), r.userData)

--- a/gtk/gtk_export_since_3_10.go
+++ b/gtk/gtk_export_since_3_10.go
@@ -10,8 +10,6 @@ import (
 	"github.com/gotk3/gotk3/glib"
 )
 
-// TODO: figure out a way to determine when we can clean up
-
 //export goListBoxFilterFuncs
 func goListBoxFilterFuncs(row *C.GtkListBoxRow, userData C.gpointer) C.gboolean {
 	id := int(uintptr(userData))

--- a/gtk/gtk_export_since_3_10.go
+++ b/gtk/gtk_export_since_3_10.go
@@ -16,10 +16,9 @@ import (
 func goListBoxFilterFuncs(row *C.GtkListBoxRow, userData C.gpointer) C.gboolean {
 	id := int(uintptr(userData))
 
-	listBoxFilterFuncRegistry.Lock()
+	listBoxFilterFuncRegistry.RLock()
 	r := listBoxFilterFuncRegistry.m[id]
-	//delete(listBoxFilterFuncRegistry.m, id)
-	listBoxFilterFuncRegistry.Unlock()
+	listBoxFilterFuncRegistry.RUnlock()
 
 	return gbool(r.fn(wrapListBoxRow(glib.Take(unsafe.Pointer(row))), r.userData))
 }
@@ -28,10 +27,9 @@ func goListBoxFilterFuncs(row *C.GtkListBoxRow, userData C.gpointer) C.gboolean 
 func goListBoxHeaderFuncs(row *C.GtkListBoxRow, before *C.GtkListBoxRow, userData C.gpointer) {
 	id := int(uintptr(userData))
 
-	listBoxHeaderFuncRegistry.Lock()
+	listBoxHeaderFuncRegistry.RLock()
 	r := listBoxHeaderFuncRegistry.m[id]
-	//delete(listBoxHeaderFuncRegistry.m, id)
-	listBoxHeaderFuncRegistry.Unlock()
+	listBoxHeaderFuncRegistry.RUnlock()
 
 	r.fn(wrapListBoxRow(glib.Take(unsafe.Pointer(row))), wrapListBoxRow(glib.Take(unsafe.Pointer(before))), r.userData)
 }
@@ -40,10 +38,9 @@ func goListBoxHeaderFuncs(row *C.GtkListBoxRow, before *C.GtkListBoxRow, userDat
 func goListBoxSortFuncs(row1 *C.GtkListBoxRow, row2 *C.GtkListBoxRow, userData C.gpointer) C.gint {
 	id := int(uintptr(userData))
 
-	listBoxSortFuncRegistry.Lock()
+	listBoxSortFuncRegistry.RLock()
 	r := listBoxSortFuncRegistry.m[id]
-	//delete(listBoxSortFuncRegistry.m, id)
-	listBoxSortFuncRegistry.Unlock()
+	listBoxSortFuncRegistry.RUnlock()
 
 	return C.gint(r.fn(wrapListBoxRow(glib.Take(unsafe.Pointer(row1))), wrapListBoxRow(glib.Take(unsafe.Pointer(row2))), r.userData))
 }

--- a/gtk/gtk_export_since_3_14.go
+++ b/gtk/gtk_export_since_3_14.go
@@ -17,9 +17,9 @@ import (
 func goListBoxForEachFuncs(box *C.GtkListBox, row *C.GtkListBoxRow, userData C.gpointer) {
 	id := int(uintptr(userData))
 
-	listBoxForeachFuncRegistry.Lock()
+	listBoxForeachFuncRegistry.RLock()
 	r := listBoxForeachFuncRegistry.m[id]
-	listBoxForeachFuncRegistry.Unlock()
+	listBoxForeachFuncRegistry.RUnlock()
 
 	r.fn(wrapListBox(glib.Take(unsafe.Pointer(box))), wrapListBoxRow(glib.Take(unsafe.Pointer(row))), r.userData)
 }

--- a/gtk/gtk_export_since_3_14.go
+++ b/gtk/gtk_export_since_3_14.go
@@ -11,8 +11,6 @@ import (
 	"github.com/gotk3/gotk3/glib"
 )
 
-// TODO: figure out a way to determine when we can clean up
-
 //export goListBoxForEachFuncs
 func goListBoxForEachFuncs(box *C.GtkListBox, row *C.GtkListBoxRow, userData C.gpointer) {
 	id := int(uintptr(userData))

--- a/gtk/gtk_since_3_10.go
+++ b/gtk/gtk_since_3_10.go
@@ -404,11 +404,11 @@ func (v *ListBox) InvalidateSort() {
 	C.gtk_list_box_invalidate_sort(v.native())
 }
 
-type ListBoxFilterFunc func(row *ListBoxRow, userData uintptr) bool
+type ListBoxFilterFunc func(row *ListBoxRow, userData ...interface{}) bool
 
 type listBoxFilterFuncData struct {
 	fn       ListBoxFilterFunc
-	userData uintptr
+	userData []interface{}
 }
 
 var (
@@ -422,7 +422,7 @@ var (
 	}
 )
 
-func (v *ListBox) SetFilterFunc(fn ListBoxFilterFunc, userData uintptr) {
+func (v *ListBox) SetFilterFunc(fn ListBoxFilterFunc, userData ...interface{}) {
 	listBoxFilterFuncRegistry.Lock()
 	id := listBoxFilterFuncRegistry.next
 	listBoxFilterFuncRegistry.next++
@@ -432,11 +432,11 @@ func (v *ListBox) SetFilterFunc(fn ListBoxFilterFunc, userData uintptr) {
 	C._gtk_list_box_set_filter_func(v.native(), C.gpointer(uintptr(id)))
 }
 
-type ListBoxHeaderFunc func(row *ListBoxRow, before *ListBoxRow, userData uintptr)
+type ListBoxHeaderFunc func(row *ListBoxRow, before *ListBoxRow, userData ...interface{})
 
 type listBoxHeaderFuncData struct {
 	fn       ListBoxHeaderFunc
-	userData uintptr
+	userData []interface{}
 }
 
 var (
@@ -450,7 +450,7 @@ var (
 	}
 )
 
-func (v *ListBox) SetHeaderFunc(fn ListBoxHeaderFunc, userData uintptr) {
+func (v *ListBox) SetHeaderFunc(fn ListBoxHeaderFunc, userData ...interface{}) {
 	listBoxHeaderFuncRegistry.Lock()
 	id := listBoxHeaderFuncRegistry.next
 	listBoxHeaderFuncRegistry.next++
@@ -460,11 +460,11 @@ func (v *ListBox) SetHeaderFunc(fn ListBoxHeaderFunc, userData uintptr) {
 	C._gtk_list_box_set_header_func(v.native(), C.gpointer(uintptr(id)))
 }
 
-type ListBoxSortFunc func(row1 *ListBoxRow, row2 *ListBoxRow, userData uintptr) int
+type ListBoxSortFunc func(row1 *ListBoxRow, row2 *ListBoxRow, userData ...interface{}) int
 
 type listBoxSortFuncData struct {
 	fn       ListBoxSortFunc
-	userData uintptr
+	userData []interface{}
 }
 
 var (
@@ -478,7 +478,7 @@ var (
 	}
 )
 
-func (v *ListBox) SetSortFunc(fn ListBoxSortFunc, userData uintptr) {
+func (v *ListBox) SetSortFunc(fn ListBoxSortFunc, userData ...interface{}) {
 	listBoxSortFuncRegistry.Lock()
 	id := listBoxSortFuncRegistry.next
 	listBoxSortFuncRegistry.next++

--- a/gtk/gtk_since_3_10.go
+++ b/gtk/gtk_since_3_10.go
@@ -423,6 +423,7 @@ var (
 )
 
 func (v *ListBox) SetFilterFunc(fn ListBoxFilterFunc, userData ...interface{}) {
+	// TODO: figure out a way to determine when we can clean up
 	listBoxFilterFuncRegistry.Lock()
 	id := listBoxFilterFuncRegistry.next
 	listBoxFilterFuncRegistry.next++
@@ -451,6 +452,7 @@ var (
 )
 
 func (v *ListBox) SetHeaderFunc(fn ListBoxHeaderFunc, userData ...interface{}) {
+	// TODO: figure out a way to determine when we can clean up
 	listBoxHeaderFuncRegistry.Lock()
 	id := listBoxHeaderFuncRegistry.next
 	listBoxHeaderFuncRegistry.next++
@@ -479,6 +481,7 @@ var (
 )
 
 func (v *ListBox) SetSortFunc(fn ListBoxSortFunc, userData ...interface{}) {
+	// TODO: figure out a way to determine when we can clean up
 	listBoxSortFuncRegistry.Lock()
 	id := listBoxSortFuncRegistry.next
 	listBoxSortFuncRegistry.next++

--- a/gtk/gtk_since_3_10.go
+++ b/gtk/gtk_since_3_10.go
@@ -143,12 +143,12 @@ func ButtonNewFromIconName(iconName string, size IconSize) (*Button, error) {
  * GtkGrid
  */
 
-// RemoveRow() is a wrapper around gtk_grid_remove_row().
+// RemoveRow is a wrapper around gtk_grid_remove_row().
 func (v *Grid) RemoveRow(position int) {
 	C.gtk_grid_remove_row(v.native(), C.gint(position))
 }
 
-// RemoveColumn() is a wrapper around gtk_grid_remove_column().
+// RemoveColumn is a wrapper around gtk_grid_remove_column().
 func (v *Grid) RemoveColumn(position int) {
 	C.gtk_grid_remove_column(v.native(), C.gint(position))
 }
@@ -163,6 +163,7 @@ func (v *Grid) RemoveColumn(position int) {
  * GtkHeaderBar
  */
 
+ // HeaderBar is a representation of GtkHeaderBar
 type HeaderBar struct {
 	Container
 }
@@ -260,13 +261,13 @@ func (v *HeaderBar) GetShowCloseButton() bool {
  * GtkLabel
  */
 
-// GetLines() is a wrapper around gtk_label_get_lines().
+// GetLines is a wrapper around gtk_label_get_lines().
 func (v *Label) GetLines() int {
 	c := C.gtk_label_get_lines(v.native())
 	return int(c)
 }
 
-// SetLines() is a wrapper around gtk_label_set_lines().
+// SetLines is a wrapper around gtk_label_set_lines().
 func (v *Label) SetLines(lines int) {
 	C.gtk_label_set_lines(v.native(), C.gint(lines))
 }
@@ -404,6 +405,7 @@ func (v *ListBox) InvalidateSort() {
 	C.gtk_list_box_invalidate_sort(v.native())
 }
 
+// ListBoxFilterFunc is a representation of GtkListBoxFilterFunc
 type ListBoxFilterFunc func(row *ListBoxRow, userData ...interface{}) bool
 
 type listBoxFilterFuncData struct {
@@ -422,6 +424,7 @@ var (
 	}
 )
 
+// SetFilterFunc is a wrapper around gtk_list_box_set_filter_func
 func (v *ListBox) SetFilterFunc(fn ListBoxFilterFunc, userData ...interface{}) {
 	// TODO: figure out a way to determine when we can clean up
 	listBoxFilterFuncRegistry.Lock()
@@ -433,6 +436,7 @@ func (v *ListBox) SetFilterFunc(fn ListBoxFilterFunc, userData ...interface{}) {
 	C._gtk_list_box_set_filter_func(v.native(), C.gpointer(uintptr(id)))
 }
 
+// ListBoxHeaderFunc is a representation of GtkListBoxUpdateHeaderFunc
 type ListBoxHeaderFunc func(row *ListBoxRow, before *ListBoxRow, userData ...interface{})
 
 type listBoxHeaderFuncData struct {
@@ -451,6 +455,7 @@ var (
 	}
 )
 
+// SetHeaderFunc is a wrapper around gtk_list_box_set_header_func
 func (v *ListBox) SetHeaderFunc(fn ListBoxHeaderFunc, userData ...interface{}) {
 	// TODO: figure out a way to determine when we can clean up
 	listBoxHeaderFuncRegistry.Lock()
@@ -462,6 +467,7 @@ func (v *ListBox) SetHeaderFunc(fn ListBoxHeaderFunc, userData ...interface{}) {
 	C._gtk_list_box_set_header_func(v.native(), C.gpointer(uintptr(id)))
 }
 
+// ListBoxSortFunc is a representation of GtkListBoxSortFunc
 type ListBoxSortFunc func(row1 *ListBoxRow, row2 *ListBoxRow, userData ...interface{}) int
 
 type listBoxSortFuncData struct {
@@ -480,6 +486,7 @@ var (
 	}
 )
 
+// SetSortFunc is a wrapper around gtk_list_box_set_sort_func
 func (v *ListBox) SetSortFunc(fn ListBoxSortFunc, userData ...interface{}) {
 	// TODO: figure out a way to determine when we can clean up
 	listBoxSortFuncRegistry.Lock()

--- a/gtk/gtk_since_3_12.go
+++ b/gtk/gtk_since_3_12.go
@@ -65,7 +65,7 @@ func init() {
 	}
 }
 
-// GetLocaleDirection() is a wrapper around gtk_get_locale_direction().
+// GetLocaleDirection is a wrapper around gtk_get_locale_direction().
 func GetLocaleDirection() TextDirection {
 	c := C.gtk_get_locale_direction()
 	return TextDirection(c)
@@ -175,6 +175,8 @@ func (v *MenuButton) SetUsePopover(setting bool) {
 /*
  * FlowBox
  */
+
+// FlowBox is a representation of GtkFlowBox
 type FlowBox struct {
 	Container
 }
@@ -357,6 +359,8 @@ func (fb *FlowBox) GetSelectionMode() SelectionMode {
 /*
  * FlowBoxChild
  */
+
+// FlowBoxChild is a representation of GtkFlowBoxChild
 type FlowBoxChild struct {
 	Bin
 }
@@ -532,7 +536,7 @@ func (v *Popover) GetModal() bool {
  * TreePath
  */
 
-// TreePathNewFromIndicesv() is a wrapper around gtk_tree_path_new_from_indicesv().
+// TreePathNewFromIndicesv is a wrapper around gtk_tree_path_new_from_indicesv().
 func TreePathNewFromIndicesv(indices []int) (*TreePath, error) {
 	if len(indices) == 0 {
 		return nil, errors.New("no indice")

--- a/gtk/gtk_since_3_14.go
+++ b/gtk/gtk_since_3_14.go
@@ -51,11 +51,11 @@ func (v *ListBox) UnselectAll() {
 	C.gtk_list_box_unselect_all(v.native())
 }
 
-type ListBoxForeachFunc func(box *ListBox, row *ListBoxRow, userData uintptr) int
+type ListBoxForeachFunc func(box *ListBox, row *ListBoxRow, userData ...interface{}) int
 
 type listBoxForeachFuncData struct {
 	fn       ListBoxForeachFunc
-	userData uintptr
+	userData []interface{}
 }
 
 var (
@@ -70,7 +70,7 @@ var (
 )
 
 // SelectedForeach is a wrapper around gtk_list_box_selected_foreach().
-func (v *ListBox) SelectedForeach(fn ListBoxForeachFunc, userData uintptr) {
+func (v *ListBox) SelectedForeach(fn ListBoxForeachFunc, userData ...interface{}) {
 	listBoxForeachFuncRegistry.Lock()
 	id := listBoxForeachFuncRegistry.next
 	listBoxForeachFuncRegistry.next++

--- a/gtk/gtk_since_3_14.go
+++ b/gtk/gtk_since_3_14.go
@@ -79,6 +79,7 @@ func (v *ListBox) SelectedForeach(fn ListBoxForeachFunc, userData ...interface{}
 
 	C._gtk_list_box_selected_foreach(v.native(), C.gpointer(uintptr(id)))
 
+	// Clean up callback immediately as we only need it for the duration of this Foreach call
 	listBoxForeachFuncRegistry.Lock()
 	delete(listBoxForeachFuncRegistry.m, id)
 	listBoxForeachFuncRegistry.Unlock()

--- a/gtk/gtk_since_3_14.go
+++ b/gtk/gtk_since_3_14.go
@@ -51,6 +51,7 @@ func (v *ListBox) UnselectAll() {
 	C.gtk_list_box_unselect_all(v.native())
 }
 
+// ListBoxForeachFunc is a representation of GtkListBoxForeachFunc
 type ListBoxForeachFunc func(box *ListBox, row *ListBoxRow, userData ...interface{}) int
 
 type listBoxForeachFuncData struct {

--- a/gtk/gtk_since_3_20.go
+++ b/gtk/gtk_since_3_20.go
@@ -81,7 +81,7 @@ func (v *NativeDialog) SetModal(modal bool) {
 	C.gtk_native_dialog_set_modal(v.native(), gbool(modal))
 }
 
-// GetModal() is a wrapper around gtk_native_dialog_get_modal().
+// GetModal is a wrapper around gtk_native_dialog_get_modal().
 func (v *NativeDialog) GetModal() bool {
 	c := C.gtk_native_dialog_get_modal(v.native())
 	return gobool(c)
@@ -94,12 +94,12 @@ func (v *NativeDialog) SetTitle(title string) {
 	C.gtk_native_dialog_set_title(v.native(), (*C.char)(cstr))
 }
 
-// GetTitle() is a wrapper around gtk_native_dialog_get_title().
+// GetTitle is a wrapper around gtk_native_dialog_get_title().
 func (v *NativeDialog) GetTitle() (string, error) {
 	return stringReturn((*C.gchar)(C.gtk_native_dialog_get_title(v.native())))
 }
 
-// SetTransientFor() is a wrapper around gtk_native_dialog_set_transient_for().
+// SetTransientFor is a wrapper around gtk_native_dialog_set_transient_for().
 func (v *NativeDialog) SetTransientFor(parent IWindow) {
 	var pw *C.GtkWindow = nil
 	if parent != nil {
@@ -108,7 +108,7 @@ func (v *NativeDialog) SetTransientFor(parent IWindow) {
 	C.gtk_native_dialog_set_transient_for(v.native(), pw)
 }
 
-// GetTransientFor() is a wrapper around gtk_native_dialog_get_transient_for().
+// GetTransientFor is a wrapper around gtk_native_dialog_get_transient_for().
 func (v *NativeDialog) GetTransientFor() (*Window, error) {
 	c := C.gtk_native_dialog_get_transient_for(v.native())
 	if c == nil {
@@ -218,7 +218,7 @@ func (v *FileChooserNativeDialog) SetAcceptLabel(accept_label string) {
 	C.gtk_file_chooser_native_set_accept_label(v.native(), (*C.char)(cstr))
 }
 
-// GetAcceptLabel() is a wrapper around gtk_file_chooser_native_get_accept_label().
+// GetAcceptLabel is a wrapper around gtk_file_chooser_native_get_accept_label().
 func (v *FileChooserNativeDialog) GetAcceptLabel() (string, error) {
 	return stringReturn((*C.gchar)(C.gtk_file_chooser_native_get_accept_label(v.native())))
 }
@@ -230,7 +230,7 @@ func (v *FileChooserNativeDialog) SetCancelLabel(cancel_label string) {
 	C.gtk_file_chooser_native_set_cancel_label(v.native(), (*C.char)(cstr))
 }
 
-// GetCancelLabel() is a wrapper around gtk_file_chooser_native_get_cancel_label().
+// GetCancelLabel is a wrapper around gtk_file_chooser_native_get_cancel_label().
 func (v *FileChooserNativeDialog) GetCancelLabel() (string, error) {
 	return stringReturn((*C.gchar)(C.gtk_file_chooser_native_get_cancel_label(v.native())))
 }

--- a/gtk/gtk_since_3_8.go
+++ b/gtk/gtk_since_3_8.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/gotk3/gotk3/gdk"
 )
+
 /*
  * Constants
  */
@@ -43,11 +44,11 @@ const (
  * GtkTickCallback
  */
 
-type TickCallback func(widget *Widget, frameClock *gdk.FrameClock, userData uintptr) bool
+type TickCallback func(widget *Widget, frameClock *gdk.FrameClock, userData ...interface{}) bool
 
 type tickCallbackData struct {
 	fn       TickCallback
-	userData uintptr
+	userData []interface{}
 }
 
 var (

--- a/gtk/gtk_since_3_8.go
+++ b/gtk/gtk_since_3_8.go
@@ -44,6 +44,7 @@ const (
  * GtkTickCallback
  */
 
+// TickCallback is a representation of GtkTickCallback
 type TickCallback func(widget *Widget, frameClock *gdk.FrameClock, userData ...interface{}) bool
 
 type tickCallbackData struct {

--- a/gtk/print.go
+++ b/gtk/print.go
@@ -954,11 +954,11 @@ func PrintRunPageSetupDialog(parent IWindow, pageSetup *PageSetup, settings *Pri
 	return wrapPageSetup(obj)
 }
 
-type PageSetupDoneCallback func(setup *PageSetup, userData uintptr)
+type PageSetupDoneCallback func(setup *PageSetup, userData ...interface{})
 
 type pageSetupDoneCallbackData struct {
 	fn   PageSetupDoneCallback
-	data uintptr
+	data []interface{}
 }
 
 var (
@@ -974,7 +974,7 @@ var (
 
 // PrintRunPageSetupDialogAsync() is a wrapper around gtk_print_run_page_setup_dialog_async().
 func PrintRunPageSetupDialogAsync(parent IWindow, setup *PageSetup,
-	settings *PrintSettings, cb PageSetupDoneCallback, data uintptr) {
+	settings *PrintSettings, cb PageSetupDoneCallback, data ...interface{}) {
 
 	pageSetupDoneCallbackRegistry.Lock()
 	id := pageSetupDoneCallbackRegistry.next
@@ -1160,11 +1160,11 @@ func (ps *PrintSettings) Unset(key string) {
 	C.gtk_print_settings_unset(ps.native(), (*C.gchar)(cstr))
 }
 
-type PrintSettingsCallback func(key, value string, userData uintptr)
+type PrintSettingsCallback func(key, value string, userData ...interface{})
 
 type printSettingsCallbackData struct {
 	fn       PrintSettingsCallback
-	userData uintptr
+	userData []interface{}
 }
 
 var (
@@ -1179,7 +1179,7 @@ var (
 )
 
 // Foreach() is a wrapper around gtk_print_settings_foreach().
-func (ps *PrintSettings) ForEach(cb PrintSettingsCallback, userData uintptr) {
+func (ps *PrintSettings) ForEach(cb PrintSettingsCallback, userData ...interface{}) {
 	printSettingsCallbackRegistry.Lock()
 	id := printSettingsCallbackRegistry.next
 	printSettingsCallbackRegistry.next++

--- a/gtk/print.go
+++ b/gtk/print.go
@@ -985,6 +985,8 @@ func PrintRunPageSetupDialogAsync(parent IWindow, setup *PageSetup,
 
 	C._gtk_print_run_page_setup_dialog_async(parent.toWindow(), setup.native(),
 		settings.native(), C.gpointer(uintptr(id)))
+
+	// This callback is cleaned up as soon as it has been called by GTK.
 }
 
 /*
@@ -1188,6 +1190,11 @@ func (ps *PrintSettings) ForEach(cb PrintSettingsCallback, userData ...interface
 	printSettingsCallbackRegistry.Unlock()
 
 	C._gtk_print_settings_foreach(ps.native(), C.gpointer(uintptr(id)))
+
+	// Clean up callback immediately as we only need it for the duration of this Foreach call
+	printSettingsCallbackRegistry.Lock()
+	delete(printSettingsCallbackRegistry.m, id)
+	printSettingsCallbackRegistry.Unlock()
 }
 
 // GetBool() is a wrapper around gtk_print_settings_get_bool().

--- a/gtk/print_test.go
+++ b/gtk/print_test.go
@@ -48,7 +48,7 @@ func TestPrintSettings(t *testing.T) {
 	settings.Set("Key3", "String2")
 	settings.SetInt("Key4", 2)
 
-	settings.ForEach(func(key, value string, ptr uintptr) {
+	settings.ForEach(func(key, value string, userData ...interface{}) {
 	}, 0)
 }
 

--- a/gtk/widget_export_since_3_8.go
+++ b/gtk/widget_export_since_3_8.go
@@ -13,15 +13,15 @@ import (
 )
 
 //export goTickCallbacks
-func goTickCallbacks (widget *C.GtkWidget, frameClock *C.GdkFrameClock, userData C.gpointer) C.gboolean {
+func goTickCallbacks(widget *C.GtkWidget, frameClock *C.GdkFrameClock, userData C.gpointer) C.gboolean {
 	id := int(uintptr(userData))
 
-	tickCallbackRegistry.Lock()
+	tickCallbackRegistry.RLock()
 	r := tickCallbackRegistry.m[id]
-	tickCallbackRegistry.Unlock()
+	tickCallbackRegistry.RUnlock()
 
 	return gbool(r.fn(
-		wrapWidget(glib.Take(unsafe.Pointer(widget))), 
+		wrapWidget(glib.Take(unsafe.Pointer(widget))),
 		gdk.WrapFrameClock(unsafe.Pointer(frameClock)),
 		r.userData,
 	))

--- a/gtk/widget_since_3_8.go
+++ b/gtk/widget_since_3_8.go
@@ -69,12 +69,17 @@ func (v *Widget) AddTickCallback(fn TickCallback, userData ...interface{}) int {
 	tickCallbackRegistry.Unlock()
 
 	return int(C._gtk_widget_add_tick_callback(v.native(), C.gpointer(uintptr(id))))
+
+	// This callback is cleaned up when calling RemoveTickCallback()
 }
 
 // RemoveTickCallback is a wrapper around gtk_widget_remove_tick_callback().
 func (v *Widget) RemoveTickCallback(id int) {
-	// TODO: remove callback from tickCallbackRegistry
 	C.gtk_widget_remove_tick_callback(v.native(), C.guint(id))
+
+	tickCallbackRegistry.Lock()
+	delete(tickCallbackRegistry.m, id)
+	tickCallbackRegistry.Unlock()
 }
 
 // TODO:

--- a/gtk/widget_since_3_8.go
+++ b/gtk/widget_since_3_8.go
@@ -27,7 +27,7 @@ package gtk
 // #include "widget_since_3_8.go.h"
 import "C"
 
-import ( 
+import (
 	"unsafe"
 
 	"github.com/gotk3/gotk3/gdk"
@@ -61,7 +61,7 @@ func (v *Widget) GetFrameClock() *gdk.FrameClock {
 }
 
 // AddTickCallback is a wrapper around gtk_widget_add_tick_callback().
-func (v *Widget) AddTickCallback(fn TickCallback, userData uintptr) int {
+func (v *Widget) AddTickCallback(fn TickCallback, userData ...interface{}) int {
 	tickCallbackRegistry.Lock()
 	id := tickCallbackRegistry.next
 	tickCallbackRegistry.next++


### PR DESCRIPTION
**Attention: Breaking Changes!**

* Use `[]interface{}` in callback signatures to have consistent "optional" user data (See #514)
* Use the READ-part of the RW locks where appropriate
* Clean up callbacks if possible (notably in ForEach calls)
* Also move the remaining cleanup TODOs next to each place where callbacks are registered