### PR TITLE
Fix build tags for 3.18

### DIFF
--- a/gtk/gtk_since_3_18.go
+++ b/gtk/gtk_since_3_18.go
@@ -1,4 +1,4 @@
-// +build !gtk_3_6,!gtk_3_8,!gtk_3_10,!gtk_3_12,!gtk_3_14,!gtk_3_16,gtk_3_18
+// +build !gtk_3_6,!gtk_3_8,!gtk_3_10,!gtk_3_12,!gtk_3_14,!gtk_3_16
 
 // See: https://developer.gnome.org/gtk3/3.18/api-index-3-18.html
 


### PR DESCRIPTION
Removed required tag `gtk_3_18` from ` gtk/gtk_since_3_18.go` so this version is also built for higher versions ( 3.20, 3.22 ).

Workaround: Use the three tags when building `-tags gtk_3_18,gtk_3_20,gtk_3_22`