### PR TITLE
updated travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,43 +7,39 @@ env:
 
 jobs:
   include:
-      # Testing on trusty, gtk 3.10.8 (gdk has same version), glib 2.40.0, gdk-pixbuf 2.30.7
-    - os: linux
-      dist: trusty
-      go: "1.13"
-
-      # Testing on xenial, gtk 3.18.9 (gdk has same version), glib 2.48.0, gdk-pixbuf 2.32.2
+      # Testing on xenial, gtk 3.18.9 (gdk has same version), glib 2.48.0 (gio has same version), gdk-pixbuf 2.32.2
     - os: linux
       dist: xenial
       go: "1.13"
 
-      # Testing on bionic, gtk 3.22.30 (gdk has same version), glib 2.56.1, gdk-pixbuf 2.36.11
+      # Testing on bionic, gtk 3.22.30 (gdk has same version), glib 2.56.1 (gio has same version), gdk-pixbuf 2.36.11
+    - os: linux
+      dist: bionic
+      go: "1.14"
+
+      # Testing on focal, gtk 3.24.14 (gdk has same version), glib 2.64.1 (gio has same version), gdk-pixbuf 2.40.0
       # Majority of the go versions here for compatibility checking
     - os: linux
-      dist: bionic
-      go: "1.8"
-    - os: linux
-      dist: bionic
+      dist: focal
       go: "1.9"
     - os: linux
-      dist: bionic
+      dist: focal
       go: "1.10"
     - os: linux
-      dist: bionic
+      dist: focal
       go: "1.11"
     - os: linux
-      dist: bionic
+      dist: focal
       go: "1.12"
     - os: linux
-      dist: bionic
+      dist: focal
       go: "1.13"
     - os: linux
-      dist: bionic
+      dist: focal
+      go: "1.14"
+    - os: linux
+      dist: focal
       go: tip
-
-      # Testing on eoan, gtk 3.24.12 (gdk has same version), glib 2.62.1, gdk-pixbuf 2.40.0
-
-      # Testing on focal, gtk 3.24.14 (gdk has same version), glib 2.64.1, gdk-pixbuf 2.40.0
 
 addons:
   apt:
@@ -57,11 +53,10 @@ before_install:
   - sudo /usr/bin/Xvfb $DISPLAY 2>1 > /dev/null &
   - "export GTK_VERSION=$(pkg-config --modversion gtk+-3.0 | tr . _| cut -d '_' -f 1-2)"
   - "export Glib_VERSION=$(pkg-config --modversion glib-2.0 | tr . _| cut -d '_' -f 1-2)"
-  - "export GDK_VERSION=$(pkg-config --modversion gdk-3.0)"
   - "export GDK_Pixbuf_VERSION=$(pkg-config --modversion gdk-pixbuf-2.0 | tr . _| cut -d '_' -f 1-2)"
   - "export Cairo_VERSION=$(pkg-config --modversion cairo)"
   - "export Pango_VERSION=$(pkg-config --modversion pango)"
-  - echo "GTK version ${GTK_VERSION} Glib version ${Glib_VERSION} Gdk-Pixbuf version ${GDK_Pixbuf_VERSION} (Gdk ${GDK_VERSION}, Cairo ${Cairo_VERSION}, Pango ${Pango_VERSION})"
+  - echo "GTK/GDK version ${GTK_VERSION} Glib/Gio version ${Glib_VERSION} Gdk-Pixbuf version ${GDK_Pixbuf_VERSION} (Cairo ${Cairo_VERSION}, Pango ${Pango_VERSION})"
 
 install:
   - go get -t -tags "gtk_${GTK_VERSION} glib_${Glib_VERSION} gdk_pixbuf_${GDK_Pixbuf_VERSION}" ./...

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ floating references.
 for better understanding see 
 [package reference documation](https://pkg.go.dev/github.com/gotk3/gotk3/gtk?tab=doc)
 
-See which version your distrobution has [here](https://pkgs.org) with the search terms:
+On Linux, see which version your distribution has [here](https://pkgs.org) with the search terms:
 * libgtk-3
 * libglib2
-* gdk-pixbuf
+* libgdk-pixbuf2
 
 ## Sample Use
 

--- a/glib/gvariant.go
+++ b/glib/gvariant.go
@@ -143,7 +143,7 @@ func VariantFromInt64(value int64) *Variant {
 
 // VariantFromByte is a wrapper around g_variant_new_byte
 func VariantFromByte(value uint8) *Variant {
-	return takeVariant(C.g_variant_new_byte(C.guchar(value)))
+	return takeVariant(C.g_variant_new_byte(C.guint8(value)))
 }
 
 // VariantFromUint16 is a wrapper around g_variant_new_uint16

--- a/gtk/gtk_since_3_18.go
+++ b/gtk/gtk_since_3_18.go
@@ -31,7 +31,7 @@ import "C"
 
 // ReorderOverlay() is a wrapper around gtk_overlay_reorder_overlay().
 func (v *Overlay) ReorderOverlay(child IWidget, position int) {
-	C.gtk_overlay_reorder_overlay(v.native(), child.toWidget(), C.gint(position))
+	C.gtk_overlay_reorder_overlay(v.native(), child.toWidget(), C.int(position))
 }
 
 // GetOverlayPassThrough() is a wrapper around gtk_overlay_get_overlay_pass_through().


### PR DESCRIPTION
added testing for
* new Ubuntu 20.04
* go version 1.14

dropping testing for
* go version 1.8 (released 3 years ago)
* Ubuntu 14.04: only Extended Security Maintenance still running