### PR TITLE
CellArea did not fully implement ICellArea interface

### DIFF
--- a/gtk/cell_area.go
+++ b/gtk/cell_area.go
@@ -32,7 +32,7 @@ type CellArea struct {
 
 type ICellArea interface {
 	toCellArea() *C.GtkCellArea
-	ToCellArea() *C.GtkCellArea
+	ToCellArea() *CellArea
 }
 
 // native returns a pointer to the underlying GtkCellArea.


### PR DESCRIPTION
`ToCellArea()` should return `*CellArea`, not `*C.GtkCellArea`

Current missing implementation makes it impossible to pass `gtk.CellAreaBox` to `gtk.TreeViewColumnNewWithArea()`