### PR TITLE
Added SelectionData into marshalers, fixed SetData and GetData crashing

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -176,7 +176,7 @@ func init() {
 		{glib.Type(C.gtk_scrollbar_get_type()), marshalScrollbar},
 		{glib.Type(C.gtk_scrolled_window_get_type()), marshalScrolledWindow},
 		{glib.Type(C.gtk_search_entry_get_type()), marshalSearchEntry},
-		//{glib.Type(C.gtk_selection_data_get_type()), marshalSelectionData},
+		{glib.Type(C.gtk_selection_data_get_type()), marshalSelectionData},
 		{glib.Type(C.gtk_separator_get_type()), marshalSeparator},
 		{glib.Type(C.gtk_separator_menu_item_get_type()), marshalSeparatorMenuItem},
 		{glib.Type(C.gtk_separator_tool_item_get_type()), marshalSeparatorToolItem},
@@ -7472,7 +7472,11 @@ func (v *SelectionData) native() *C.GtkSelectionData {
 	if v == nil {
 		return nil
 	}
-	return v.GtkSelectionData
+
+	// I don't understand why we need this, but we do.
+	c := (*C.GValue)(unsafe.Pointer(v))
+	p := (*C.GtkSelectionData)(unsafe.Pointer(c))
+	return p
 }
 
 // GetLength is a wrapper around gtk_selection_data_get_length
@@ -7492,35 +7496,20 @@ func (v *SelectionData) GetData() (data []byte) {
 	return
 }
 
-//fixed GetData directly from ptr
-func GetData(pointer uintptr) (data []byte) {
-	c := (*C.GValue)(unsafe.Pointer(pointer))
-	p := (*C.GtkSelectionData)(unsafe.Pointer(c))
-	C.gtk_selection_data_get_text(p)
-
-	var byteData []byte
-	var length C.gint
-	cptr := C.gtk_selection_data_get_data_with_length(p, &length)
-	sliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&byteData))
-	sliceHeader.Data = uintptr(unsafe.Pointer(cptr))
-	sliceHeader.Len = int(length)
-	sliceHeader.Cap = int(length)
-
-	return byteData
-}
-
-//for "drag-data-get"
-func SetData(pointer uintptr, atom gdk.Atom, data []byte) {
-	c := (*C.GValue)(unsafe.Pointer(pointer))
-	p := (*C.GtkSelectionData)(unsafe.Pointer(c))
-	C.gtk_selection_data_set(p, C.GdkAtom(unsafe.Pointer(atom)), C.gint(8), (*C.guchar)(unsafe.Pointer(&data[0])), C.gint(len(data)))
+// SetData is a wrapper around gtk_selection_data_set_data_with_length.
+func (v *SelectionData) SetData(atom gdk.Atom, data []byte) {
+	C.gtk_selection_data_set(
+		v.native(),
+		C.GdkAtom(unsafe.Pointer(atom)),
+		C.gint(8), (*C.guchar)(&data[0]), C.gint(len(data)),
+	)
 }
 
 func (v *SelectionData) free() {
 	C.gtk_selection_data_free(v.native())
 }
 
-//for "drag-begin" event
+// DragSetIconPixbuf is used for the "drag-begin" event. It binds to gtk_drag_set_icon_pixbuf.
 func DragSetIconPixbuf(context *gdk.DragContext, pixbuf *gdk.Pixbuf, hot_x int, hot_y int) {
 	ctx := unsafe.Pointer(context.Native())
 	pix := unsafe.Pointer(pixbuf.Native())


### PR DESCRIPTION
This PR fixes the two below crashes, as well as adding SelectionData into the list of known Glib marshalers for use in Connect callback arguments.

**Note:** This PR breaks existing code using `gtk.SetData(uintptr(unsafe.Pointer(v)), ...)`, which may or may not be a good thing (as the use of `uintptr` in the API should be discouraged).

The crash for SetData:
```
fatal error: unexpected signal during runtime execution
[signal SIGSEGV: segmentation violation code=0x1 addr=0xc8 pc=0x7f3fa47abba0]

runtime stack:
runtime.throw(0xd67467, 0x2a)
	/nix/store/1r61f7iwqfb6dm1krqpj9cjfifjnfmjx-go-1.14.2/share/go/src/runtime/panic.go:1116 +0x72
runtime.sigpanic()
	/nix/store/1r61f7iwqfb6dm1krqpj9cjfifjnfmjx-go-1.14.2/share/go/src/runtime/signal_unix.go:679 +0x46a

goroutine 1 [syscall, locked to thread]:
runtime.cgocall(0xb7b080, 0xc0004616e0, 0xc00074c420)
	/nix/store/1r61f7iwqfb6dm1krqpj9cjfifjnfmjx-go-1.14.2/share/go/src/runtime/cgocall.go:133 +0x5b fp=0xc0004616b0 sp=0xc000461678 pc=0x48560b
github.com/gotk3/gotk3/gtk._Cfunc_gtk_selection_data_set(0xa8, 0x82, 0x8, 0xc00002bc40, 0xc000000011)
	_cgo_gotypes.go:22496 +0x45 fp=0xc0004616e0 sp=0xc0004616b0 pc=0x605c75
github.com/gotk3/gotk3/gtk.(*SelectionData).SetData.func1(0x7ffddb25e9b0, 0x82, 0xc00002bc40, 0x11, 0x20)
	/home/diamond/Scripts/gotk3/gtk/gtk.go:7516 +0xc1 fp=0xc000461728 sp=0xc0004616e0 pc=0x69c291
github.com/gotk3/gotk3/gtk.(*SelectionData).SetData(0x7ffddb25e9b0, 0x82, 0xc00002bc40, 0x11, 0x20)
	/home/diamond/Scripts/gotk3/gtk/gtk.go:7516 +0x53 fp=0xc000461760 sp=0xc000461728 pc=0x64c163
```

The crash for GetData:

```
fatal error: unexpected signal during runtime execution
[signal SIGSEGV: segmentation violation code=0x1 addr=0xd0 pc=0x7f3ec0e36b05]

runtime stack:
runtime.throw(0xd67467, 0x2a)
	/nix/store/1r61f7iwqfb6dm1krqpj9cjfifjnfmjx-go-1.14.2/share/go/src/runtime/panic.go:1116 +0x72
runtime.sigpanic()
	/nix/store/1r61f7iwqfb6dm1krqpj9cjfifjnfmjx-go-1.14.2/share/go/src/runtime/signal_unix.go:679 +0x46a

goroutine 1 [syscall, locked to thread]:
runtime.cgocall(0xb7afa0, 0xc0001596c8, 0x30)
	/nix/store/1r61f7iwqfb6dm1krqpj9cjfifjnfmjx-go-1.14.2/share/go/src/runtime/cgocall.go:133 +0x5b fp=0xc000159698 sp=0xc000159660 pc=0x48560b
github.com/gotk3/gotk3/gtk._Cfunc_gtk_selection_data_get_data_with_length(0xa8, 0xc000574058, 0x0)
	_cgo_gotypes.go:22444 +0x4e fp=0xc0001596c8 sp=0xc000159698 pc=0x605aee
github.com/gotk3/gotk3/gtk.(*SelectionData).GetData.func1(0x7ffe77a8c000, 0xc000574058, 0xc0000f6540)
	/home/diamond/Scripts/gotk3/gtk/gtk.go:7487 +0x64 fp=0xc000159700 sp=0xc0001596c8 pc=0x69c1a4
github.com/gotk3/gotk3/gtk.(*SelectionData).GetData(0x7ffe77a8c000, 0x0, 0x0, 0x0)
	/home/diamond/Scripts/gotk3/gtk/gtk.go:7487 +0x56 fp=0xc000159730 sp=0xc000159700 pc=0x64c0d6
```