### PR TITLE
Add DIALOG_USE_HEADER_BAR to gtk.DialogFlags

### DIFF
--- a/gtk/gtk_since_3_12.go
+++ b/gtk/gtk_since_3_12.go
@@ -38,6 +38,10 @@ import (
  */
 
 const (
+	DIALOG_USE_HEADER_BAR DialogFlags = C.GTK_DIALOG_USE_HEADER_BAR
+)
+
+const (
 	STATE_FLAG_LINK    StateFlags = C.GTK_STATE_FLAG_LINK
 	STATE_FLAG_VISITED StateFlags = C.GTK_STATE_FLAG_VISITED
 )


### PR DESCRIPTION
Ran into an issue while reading the GtkDialog documentation and trying to create a dialog with a custom HeaderBar.

Found the additional flag [here](https://developer.gnome.org/gtk3/stable/GtkDialog.html#GtkDialogFlags)