### PR TITLE
Make it possible to disable hyphenation on labels

### DIFF
--- a/gtk/label.go
+++ b/gtk/label.go
@@ -69,8 +69,10 @@ func (v *Label) SetText(str string) {
 
 // TODO:
 // gtk_label_set_text_with_mnemonic().
-// gtk_label_set_attributes().
 // gtk_label_get_attributes().
+func (v *Label) SetAttributes(attributes *pango.AttrList) {
+	C.gtk_label_set_attributes(v.native(), (*C.PangoAttrList)(unsafe.Pointer(attributes.Native())))
+}
 
 // SetMarkup is a wrapper around gtk_label_set_markup().
 func (v *Label) SetMarkup(str string) {

--- a/pango/pango-attributes.go
+++ b/pango/pango-attributes.go
@@ -105,6 +105,17 @@ func (v *AttrList) native() *C.PangoAttrList {
 	return (*C.PangoAttrList)(unsafe.Pointer(v.pangoAttrList))
 }
 
+func (v *AttrList) Insert(attribute *Attribute) {
+	C.pango_attr_list_insert(v.pangoAttrList, attribute.native())
+}
+
+func AttrListNew() *AttrList {
+	c := C.pango_attr_list_new()
+	attrList := new(AttrList)
+	attrList.pangoAttrList = c
+	return attrList
+}
+
 // AttrType is a representation of Pango's PangoAttrType.
 type AttrType int
 
@@ -174,6 +185,13 @@ func (v *Attribute) Native() uintptr {
 
 func (v *Attribute) native() *C.PangoAttribute {
 	return (*C.PangoAttribute)(unsafe.Pointer(v.pangoAttribute))
+}
+
+func AttrInsertHyphensNew(insertHyphens bool) *Attribute {
+	c := C.pango_attr_insert_hyphens_new(gbool(insertHyphens))
+	attr := new(Attribute)
+	attr.pangoAttribute = c
+	return attr
 }
 
 /*


### PR DESCRIPTION
I've implemented a few functions to allow the usage of Pango attributes to disable automatic hyphenation on labels.