### PR TITLE
Fix gtk_since_3_10.go

### DIFF
--- a/gtk/gtk_since_3_10.go
+++ b/gtk/gtk_since_3_10.go
@@ -11,6 +11,7 @@ package gtk
 // #include "gtk_since_3_10.go.h"
 import "C"
 import (
+	"errors"
 	"sync"
 	"unsafe"
 


### PR DESCRIPTION
```
$ go get github.com/gotk3/gotk3/gtk
# github.com/gotk3/gotk3/gtk
/home/infinoid/go/src/github.com/gotk3/gotk3/gtk/gtk_since_3_10.go:124:15: undefined: errors
```

This error occurs on debian bullseye (testing), with these package versions:

```
ii  golang-1.14-go       1.14.7-2     amd64        Go programming language compiler, linker, compiled stdlib
ii  libcairo2-dev:amd64  1.16.0-4     amd64        Development files for the Cairo 2D graphics library
ii  libglib2.0-dev:amd64 2.64.4-1     amd64        Development files for the GLib library
ii  libgtk-3-dev:amd64   3.24.22-1    amd64        development files for the GTK library
```

Adding an import fixes it.
