### PR TITLE
Hfmrow patch g icon

### DIFF
--- a/gio/gio.go
+++ b/gio/gio.go
@@ -1,0 +1,221 @@
+package gio
+
+// #cgo pkg-config: gio-2.0 glib-2.0 gobject-2.0
+// #include <gio/gio.h>
+// #include <stdlib.h>
+// #include "gio.go.h"
+import "C"
+import (
+	"errors"
+	"runtime"
+	"unsafe"
+
+	"github.com/gotk3/gotk3/glib"
+)
+
+func init() {
+
+	tm := []glib.TypeMarshaler{
+		{glib.Type(C.g_icon_get_type()), marshalIcon},
+		{glib.Type(C.g_file_get_type()), marshalFile},
+		{glib.Type(C.g_file_icon_get_type()), marshalFileIcon},
+	}
+
+	glib.RegisterGValueMarshalers(tm)
+}
+
+/*
+ * Unexported vars
+ */
+
+var nilPtrErr = errors.New("cgo returned unexpected nil pointer")
+
+/*
+ * GIcon
+ */
+
+// Icon is a representation of GIO's GIcon.
+// Interface for icons
+type Icon struct {
+	*glib.Object
+}
+
+// native returns a pointer to the underlying GIcon.
+func (v *Icon) native() *C.GIcon {
+	if v == nil || v.GObject == nil {
+		return nil
+	}
+	p := unsafe.Pointer(v.GObject)
+	return C.toGIcon(p)
+}
+
+// NativePrivate: to be used inside Gotk3 only.
+func (v *Icon) NativePrivate() *C.GIcon {
+	if v == nil || v.GObject == nil {
+		return nil
+	}
+	p := unsafe.Pointer(v.GObject)
+	return C.toGIcon(p)
+}
+
+// Native returns a pointer to the underlying GIcon.
+func (v *Icon) Native() uintptr {
+	return uintptr(unsafe.Pointer(v.native()))
+}
+
+func marshalIcon(p uintptr) (interface{}, error) {
+	c := C.g_value_get_object((*C.GValue)(unsafe.Pointer(p)))
+	obj := glib.Take(unsafe.Pointer(c))
+	return wrapIcon(obj), nil
+}
+
+func wrapIcon(obj *glib.Object) *Icon {
+	return &Icon{obj}
+}
+
+// TODO I dont know how to handle it ...
+/*
+guint
+g_icon_hash (gconstpointer icon);
+*/
+
+// Equal is a wrapper around g_icon_equal().
+func (v *Icon) Equal(icon *Icon) bool {
+	return gobool(C.g_icon_equal(v.native(), icon.native()))
+}
+
+// ToString is a wrapper around g_icon_to_string().
+func (v *Icon) ToString() string {
+	return goString(C.g_icon_to_string(v.native()))
+}
+
+// IconNewForString is a wrapper around g_icon_new_for_string().
+func IconNewForString(str string) (*Icon, error) {
+	cstr := C.CString(str)
+	defer C.free(unsafe.Pointer(cstr))
+
+	var err *C.GError
+	c := C.g_icon_new_for_string((*C.char)(cstr), &err)
+	if c == nil {
+		defer C.g_error_free(err)
+		return nil, errors.New(C.GoString((*C.char)(err.message)))
+	}
+
+	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
+	i := &Icon{obj}
+
+	runtime.SetFinalizer(i, func(_ interface{}) { obj.Unref() })
+	return i, nil
+}
+
+// TODO Requiere GVariant
+/*
+GVariant * 	g_icon_serialize ()
+GIcon * 	g_icon_deserialize ()
+*/
+
+/*
+ * GFileIcon
+ */
+
+// FileIcon is a representation of GIO's GFileIcon.
+type FileIcon struct {
+	*glib.Object
+}
+
+// native returns a pointer to the underlying GFileIcon.
+func (v *FileIcon) native() *C.GFileIcon {
+	if v == nil || v.GObject == nil {
+		return nil
+	}
+	p := unsafe.Pointer(v.GObject)
+	return C.toGFileIcon(p)
+}
+
+// NativePrivate: to be used inside Gotk3 only.
+func (v *FileIcon) NativePrivate() *C.GFileIcon {
+	if v == nil || v.GObject == nil {
+		return nil
+	}
+	p := unsafe.Pointer(v.GObject)
+	return C.toGFileIcon(p)
+}
+
+// Native returns a pointer to the underlying GFileIcon.
+func (v *FileIcon) Native() uintptr {
+	return uintptr(unsafe.Pointer(v.native()))
+}
+
+func marshalFileIcon(p uintptr) (interface{}, error) {
+	c := C.g_value_get_object((*C.GValue)(unsafe.Pointer(p)))
+	obj := glib.Take(unsafe.Pointer(c))
+	return wrapFileIcon(obj), nil
+}
+
+func wrapFileIcon(obj *glib.Object) *FileIcon {
+	return &FileIcon{obj}
+}
+
+// FileIconNew is a wrapper around g_file_icon_new().
+func FileIconNew(file *File) (*Icon, error) {
+
+	c := C.g_file_icon_new(file.native())
+	if c == nil {
+		return nil, nilPtrErr
+	}
+	return wrapIcon(glib.Take(unsafe.Pointer(c))), nil
+}
+
+/*
+ * GFile
+ */
+
+// File is a representation of GIO's GFile.
+type File struct {
+	*glib.Object
+}
+
+// native returns a pointer to the underlying GFile.
+func (v *File) native() *C.GFile {
+	if v == nil || v.GObject == nil {
+		return nil
+	}
+	p := unsafe.Pointer(v.GObject)
+	return C.toGFile(p)
+}
+
+// NativePrivate: to be used inside Gotk3 only.
+func (v *File) NativePrivate() *C.GFile {
+	if v == nil || v.GObject == nil {
+		return nil
+	}
+	p := unsafe.Pointer(v.GObject)
+	return C.toGFile(p)
+}
+
+// Native returns a pointer to the underlying GFile.
+func (v *File) Native() uintptr {
+	return uintptr(unsafe.Pointer(v.native()))
+}
+
+func marshalFile(p uintptr) (interface{}, error) {
+	c := C.g_value_get_object((*C.GValue)(unsafe.Pointer(p)))
+	obj := glib.Take(unsafe.Pointer(c))
+	return wrapFile(obj), nil
+}
+
+func wrapFile(obj *glib.Object) *File {
+	return &File{obj}
+}
+
+// FileNewForPath is a wrapper around g_file_new_for_path().
+func FileNewForPath(path string) (*File, error) {
+	cstr := (*C.char)(C.CString(path))
+	defer C.free(unsafe.Pointer(cstr))
+
+	c := C.g_file_new_for_path(cstr)
+	if c == nil {
+		return nil, nilPtrErr
+	}
+	return wrapFile(glib.Take(unsafe.Pointer(c))), nil
+}

--- a/gio/gio.go.h
+++ b/gio/gio.go.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <glib.h>
+#include <gio/gio.h>
+
+static inline char** next_charptr(char** s) { return (s+1); }
+
+static inline void char_g_strfreev(char** s) {
+    g_strfreev((gchar**) s);
+}
+
+static GIcon *
+toGIcon(void *p)
+{
+	return (G_ICON(p));
+}
+
+static GFileIcon *
+toGFileIcon(void *p)
+{
+	return (G_FILE_ICON(p));
+}
+
+static GFile *
+toGFile(void *p)
+{
+	return (G_FILE(p));
+}
+

--- a/gio/utils.go
+++ b/gio/utils.go
@@ -21,3 +21,14 @@ func toGoStringArray(c **C.char) []string {
 func goString(cstr *C.gchar) string {
 	return C.GoString((*C.char)(cstr))
 }
+
+func gbool(b bool) C.gboolean {
+	if b {
+		return C.gboolean(1)
+	}
+	return C.gboolean(0)
+}
+
+func gobool(b C.gboolean) bool {
+	return b != C.FALSE
+}

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -8616,7 +8616,7 @@ func (v *TextBuffer) SetText(text string) {
 // GetIterAtMark() is a wrapper around gtk_text_buffer_get_iter_at_mark().
 func (v *TextBuffer) GetIterAtMark(mark *TextMark) *TextIter {
 	var iter C.GtkTextIter
-	C.gtk_text_buffer_get_iter_at_mark(v.native(), &iter, (*C.GtkTextMark)(mark))
+	C.gtk_text_buffer_get_iter_at_mark(v.native(), &iter, mark.native())
 	return (*TextIter)(&iter)
 }
 
@@ -8625,7 +8625,7 @@ func (v *TextBuffer) CreateMark(mark_name string, where *TextIter, left_gravity 
 	cstr := C.CString(mark_name)
 	defer C.free(unsafe.Pointer(cstr))
 	ret := C.gtk_text_buffer_create_mark(v.native(), (*C.gchar)(cstr), (*C.GtkTextIter)(where), gbool(left_gravity))
-	return (*TextMark)(ret)
+	return wrapTextMark(glib.Take(unsafe.Pointer(ret)))
 }
 
 // GetMark() is a wrapper around gtk_text_buffer_get_mark().
@@ -8633,12 +8633,12 @@ func (v *TextBuffer) GetMark(mark_name string) *TextMark {
 	cstr := C.CString(mark_name)
 	defer C.free(unsafe.Pointer(cstr))
 	ret := C.gtk_text_buffer_get_mark(v.native(), (*C.gchar)(cstr))
-	return (*TextMark)(ret)
+	return wrapTextMark(glib.Take(unsafe.Pointer(ret)))
 }
 
 // DeleteMark() is a wrapper around gtk_text_buffer_delete_mark()
 func (v *TextBuffer) DeleteMark(mark *TextMark) {
-	C.gtk_text_buffer_delete_mark(v.native(), (*C.GtkTextMark)(mark))
+	C.gtk_text_buffer_delete_mark(v.native(), mark.native())
 }
 
 // DeleteMarkByName() is a wrapper around  gtk_text_buffer_delete_mark_by_name()
@@ -8667,7 +8667,7 @@ func (v *TextBuffer) DeleteSelection(interactive, defaultEditable bool) bool {
 // GetSelectionBound() is a wrapper around gtk_text_buffer_get_selection_bound().
 func (v *TextBuffer) GetSelectionBound() *TextMark {
 	ret := C.gtk_text_buffer_get_selection_bound(v.native())
-	return (*TextMark)(ret)
+	return wrapTextMark(glib.Take(unsafe.Pointer(ret)))
 }
 
 // GetSelectionBounds() is a wrapper around gtk_text_buffer_get_selection_bounds().
@@ -8758,7 +8758,7 @@ func (v *TextBuffer) Deserialize(contentBuffer *TextBuffer, format gdk.Atom, ite
 // GetInsert() is a wrapper around gtk_text_buffer_get_insert().
 func (v *TextBuffer) GetInsert() *TextMark {
 	ret := C.gtk_text_buffer_get_insert(v.native())
-	return (*TextMark)(ret)
+	return wrapTextMark(glib.Take(unsafe.Pointer(ret)))
 }
 
 // CopyClipboard() is a wrapper around gtk_text_buffer_copy_clipboard().


### PR DESCRIPTION
- GIcon comes with marshaler, wrapper ... and:
g_icon_equal()
g_icon_to_string()
g_icon_new_for_string()

- GFileIcon comes with marshaler, wrapper ... and:
g_file_icon_new()
(the actual implementation is not really correct mixing GFileIcon and GFile to obtain a GIcon and was made under glib instead of gio ...)
take a look at: gotk3/glib/gfile.go and gotk3/glib/gicon.go

- GFile comes with marshaler, wrapper ... and:
g_file_new_for_path()

@andre-hub
My last PR: #656, #657, #658 and this one, are made to prepare GtkSource implementation that will come after merge.
Actually i've made implementation of GtkSourceView and his component (-+85%) and i use it into my own projects.
This will be usable for focal (sure) (20.04LTS) with libgtksourceview-4-dev and maybe (not sure) for xenial (16.04LTS), bionic (18.04LTS) with libgtksourceview-3.0-dev.

ps: I will update 'gtk.go' wit some methods (3) that use GIcon that was marked as TODO by jrick from long time ago. All methods was tested successfully.