### PR TITLE
Remove INPUT_PURPOSE_TERMINAL from gtk.go

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -571,7 +571,6 @@ const (
 	INPUT_PURPOSE_NAME      InputPurpose = C.GTK_INPUT_PURPOSE_NAME
 	INPUT_PURPOSE_PASSWORD  InputPurpose = C.GTK_INPUT_PURPOSE_PASSWORD
 	INPUT_PURPOSE_PIN       InputPurpose = C.GTK_INPUT_PURPOSE_PIN
-	INPUT_PURPOSE_TERMINAL  InputPurpose = C.GTK_INPUT_PURPOSE_TERMINAL
 )
 
 func marshalInputPurpose(p uintptr) (interface{}, error) {


### PR DESCRIPTION
It is conditionally defined by [gtk_since_3_24.go](https://github.com/gotk3/gotk3/blob/master/gtk/gtk_since_3_24.go#L14), instead.