### PR TITLE
Add GtkCellEditable & some GtkCellRenderer methods

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -2266,7 +2266,7 @@ func wrapCellRenderer(obj *glib.Object) *CellRenderer {
 }
 
 // Activate is a wrapper around gtk_cell_renderer_activate().
-func (v *CellRenderer) Activate(event *gdk.Event, widget *Widget, path string,
+func (v *CellRenderer) Activate(event *gdk.Event, widget IWidget, path string,
 	backgroundArea, cellArea *gdk.Rectangle, flags CellRendererState) bool {
 
 	cstr := C.CString(path)
@@ -2281,7 +2281,7 @@ func (v *CellRenderer) Activate(event *gdk.Event, widget *Widget, path string,
 }
 
 // StartEditing is a wrapper around gtk_cell_renderer_start_editing().
-func (v *CellRenderer) StartEditing(event *gdk.Event, widget *Widget, path string,
+func (v *CellRenderer) StartEditing(event *gdk.Event, widget IWidget, path string,
 	backgroundArea, cellArea *gdk.Rectangle, flags CellRendererState) (*CellEditable, error) {
 
 	cstr := C.CString(path)

--- a/gtk/gtk.go.h
+++ b/gtk/gtk.go.h
@@ -448,6 +448,12 @@ toGtkCellRenderer(void *p)
 	return (GTK_CELL_RENDERER(p));
 }
 
+static GtkCellEditable *
+toGtkCellEditable(void *p)
+{
+	return (GTK_CELL_EDITABLE(p));
+}
+
 static GtkCellRendererPixbuf *
 toGtkCellRendererPixbuf(void *p)
 {


### PR DESCRIPTION
Created Binding for: GtkCellEditable
GtkCellEditableIface + all object's implementation.
gtk_cell_editable_remove_widget
gtk_cell_editable_editing_done
gtk_cell_editable_start_editing


Add Binding for: GtkCellRenderer
gtk_cell_renderer_activate
gtk_cell_renderer_start_editing
gtk_cell_renderer_stop_editing
gtk_cell_renderer_get_visible
gtk_cell_renderer_set_visible
gtk_cell_renderer_get_sensitive
gtk_cell_renderer_set_sensitive
gtk_cell_renderer_is_activatable
gtk_cell_renderer_get_state