### PR TITLE
Add some bindings TreeModel, CellRenderer, CellEditable

### DIFF
--- a/gtk/app_chooser.go
+++ b/gtk/app_chooser.go
@@ -112,8 +112,9 @@ func marshalAppChooserButton(p uintptr) (interface{}, error) {
 
 func wrapAppChooserButton(obj *glib.Object) *AppChooserButton {
 	cl := wrapCellLayout(obj)
+	ce := wrapCellEditable(obj)
 	ac := wrapAppChooser(obj)
-	return &AppChooserButton{ComboBox{Bin{Container{Widget{glib.InitiallyUnowned{obj}}}}, *cl}, *ac}
+	return &AppChooserButton{ComboBox{Bin{Container{Widget{glib.InitiallyUnowned{obj}}}}, *cl, *ce}, *ac}
 }
 
 // AppChooserButtonNew() is a wrapper around gtk_app_chooser_button_new().
@@ -357,7 +358,7 @@ func AppChooserDialogNewForContentType(parent IWindow, flags DialogFlags, conten
 	if parent != nil {
 		pw = parent.toWindow()
 	}
-	
+
 	c := C.gtk_app_chooser_dialog_new_for_content_type(pw, C.GtkDialogFlags(flags), (*C.gchar)(cstr))
 	if c == nil {
 		return nil, nilPtrErr

--- a/gtk/cell_area.go
+++ b/gtk/cell_area.go
@@ -352,8 +352,11 @@ func (v *CellArea) GetEditedCell() (ICellRenderer, error) {
 	return castCellRenderer(c)
 }
 
-// TODO:
-// gtk_cell_area_get_edit_widget // depends on GtkCellEditable
+// GetEditWidget is a wrapper around gtk_cell_area_get_edit_widget().
+func (v *CellArea) GetEditWidget() (ICellEditable, error) {
+	c := C.gtk_cell_area_get_edit_widget(v.native())
+	return castCellEditable(c)
+}
 
 // ActivateCell is a wrapper around gtk_cell_area_activate_cell().
 func (v *CellArea) ActivateCell(widget IWidget, renderer ICellRenderer,

--- a/gtk/combo_box.go
+++ b/gtk/combo_box.go
@@ -34,6 +34,7 @@ type ComboBox struct {
 
 	// Interfaces
 	CellLayout
+	CellEditable
 }
 
 // native returns a pointer to the underlying GtkComboBox.
@@ -60,7 +61,8 @@ func marshalComboBox(p uintptr) (interface{}, error) {
 
 func wrapComboBox(obj *glib.Object) *ComboBox {
 	cl := wrapCellLayout(obj)
-	return &ComboBox{Bin{Container{Widget{glib.InitiallyUnowned{obj}}}}, *cl}
+	ce := wrapCellEditable(obj)
+	return &ComboBox{Bin{Container{Widget{glib.InitiallyUnowned{obj}}}}, *cl, *ce}
 }
 
 // ComboBoxNew is a wrapper around gtk_combo_box_new().

--- a/gtk/gtk.go.h
+++ b/gtk/gtk.go.h
@@ -448,6 +448,12 @@ toGtkCellRenderer(void *p)
 	return (GTK_CELL_RENDERER(p));
 }
 
+static GtkCellEditable *
+toGtkCellEditable(void *p)
+{
+	return (GTK_CELL_EDITABLE(p));
+}
+
 static GtkCellRendererPixbuf *
 toGtkCellRendererPixbuf(void *p)
 {


### PR DESCRIPTION
Add gtk_tree_model_get_string_from_iter.

Add GtkCellEditable & some GtkCellRenderer methods.

-Created Binding for GtkCellEditable
 gtk_cell_editable_remove_widget
 gtk_cell_editable_editing_done
 gtk_cell_editable_start_editing

-GtkCellEditableIface + all object's implementation.

-I modified other objects to integrate them with the 'GtkCellEditable' interface: https://developer.gnome.org/gtk3/stable/GtkCellEditable.html#GtkCellEditable.implementations
 So, GtkAppChooserButton, GtkComboBox, GtkComboBoxText, GtkEntry, GtkSearchEntry and GtkSpinButton have the 'GtkCellEditable' interface implemented correctly as the Gtk3 manual says.

-Add Binding for: GtkCellRenderer
 gtk_cell_renderer_activate
 gtk_cell_renderer_start_editing
 gtk_cell_renderer_stop_editing
 gtk_cell_renderer_get_visible
 gtk_cell_renderer_set_visible
 gtk_cell_renderer_get_sensitive
 gtk_cell_renderer_set_sensitive 
 gtk_cell_renderer_is_activatable
 gtk_cell_renderer_get_state

-Modified objects:
 GtkAppChooserButton ok
 GtkComboBox ok
 GtkComboBoxText ok
 GtkEntry ok
 GtkSearchEntry ok
 GtkSpinButton ok

-Modified files:
 github.com/gotk3/gotk3/gtk/app_chooser.go
 github.com/gotk3/gotk3/gtk/cell_area.go
 github.com/gotk3/gotk3/gtk/combo_box.go
 github.com/gotk3/gotk3/gtk/gtk.go
 github.com/gotk3/gotk3/gtk/gtk.go.h