### PR TITLE
Fixed glib signals missing mutex

### DIFF
--- a/glib/connect.go
+++ b/glib/connect.go
@@ -36,7 +36,9 @@ func (v *Object) connectClosure(after bool, detailedSignal string, f interface{}
 	handle := SignalHandle(c)
 
 	// Map the signal handle to the closure.
-	signals[handle] = closure
+	signals.Lock()
+	signals.m[handle] = closure
+	signals.Unlock()
 
 	return handle, nil
 }


### PR DESCRIPTION
Prior to this code, concurrent calls to `object.Connect` might cause a `panic: concurrent map writes` crash. As GLib is meant to be thread-safe (and the `closures` map is already guarded inside a mutex), the `signals` map (the origin of the crash) should also be guarded.