### PR TITLE
Add missing gtk_widget_get_scale_factor

### DIFF
--- a/gtk/widget.go
+++ b/gtk/widget.go
@@ -423,7 +423,11 @@ func (v *Widget) Unmap() {
 //void gtk_widget_queue_resize(GtkWidget *widget);
 //void gtk_widget_queue_resize_no_redraw(GtkWidget *widget);
 // gtk_widget_queue_allocate().
-// gtk_widget_get_scale_factor().
+
+// GetScaleFactor() is a wrapper around gtk_widget_get_scale_factor().
+func (v *Widget) GetScaleFactor() int {
+	return int(C.gtk_widget_get_scale_factor(v.native()))
+}
 
 // Event() is a wrapper around gtk_widget_event().
 func (v *Widget) Event(event *gdk.Event) bool {


### PR DESCRIPTION
Useful when dealing with HiDPI displays as documented in
https://gitlab.gnome.org/GNOME/gtk/-/issues/613