### PR TITLE
Refactor internal closure handling and several API changes

### DIFF
--- a/gdk/gdk_since_3_10.go
+++ b/gdk/gdk_since_3_10.go
@@ -44,11 +44,7 @@ func CairoSurfaceCreateFromPixbuf(pixbuf *Pixbuf, scale int, window *Window) (*c
 	}
 
 	surface := cairo.WrapSurface(uintptr(unsafe.Pointer(v)))
-	// Keep pixbuf alive.
-	runtime.SetFinalizer(surface, func(surface *cairo.Surface) {
-		runtime.KeepAlive(pixbuf)
-		surface.Close()
-	})
+	runtime.SetFinalizer(surface, (*cairo.Surface).Close)
 
 	return surface, nil
 }

--- a/glib/connect.go
+++ b/glib/connect.go
@@ -116,7 +116,9 @@ func (v *Object) connectClosure(after bool, detailedSignal string, f interface{}
 	// TODO: There's a slight race condition here, where
 	// g_signal_connect_closure may trigger signal callbacks before the signal
 	// is registered. It is therefore ideal to have another intermediate ID to
-	// pass into the connect function.
+	// pass into the connect function. This is not a big issue though, since
+	// there isn't really any guarantee that signals should arrive until after
+	// the Connect functions return successfully.
 	closure.RegisterSignal(uint(c), unsafe.Pointer(gclosure))
 
 	return SignalHandle(c)

--- a/glib/connect.go
+++ b/glib/connect.go
@@ -38,10 +38,6 @@ type SignalHandle uint
 //
 //    obj.Connect(func() { obj.Do() })
 //
-// By default, the direct referencing piece of code will trigger a runtime panic
-// upon registering, unless ClosureCheckReceiver is set to false. This is to
-// ensure the minimum correct behavior in most scenarios.
-//
 // When using Connect, beware of referencing variables outside the closure that
 // may cause a circular reference that prevents both Go from garbage collecting
 // the callback and GTK from successfully unreferencing its values.
@@ -83,7 +79,10 @@ func (v *Object) ConnectAfter(detailedSignal string, f interface{}) SignalHandle
 // closure's first argument to ensure that it is correct, otherwise it will
 // panic with a message warning about the possible circular references. The
 // receiver in this case is most often the first argument of the callback.
-var ClosureCheckReceiver = true
+//
+// This constant can be changed by using go.mod's replace directive for
+// debugging purposes.
+const ClosureCheckReceiver = false
 
 func (v *Object) connectClosure(after bool, detailedSignal string, f interface{}) SignalHandle {
 	fs := closure.NewFuncStack(f, 2)

--- a/glib/connect.go
+++ b/glib/connect.go
@@ -86,8 +86,8 @@ func (v *Object) connectClosure(after bool, detailedSignal string, f interface{}
 			fs.Panicf("callback should have the object parameter to avoid circular references")
 		}
 		objType := reflect.TypeOf(objValue)
-		if fsType.In(0) != objType {
-			fs.Panicf("first parameter type mismatch: expected %s, got %s", objType, fsType)
+		if first := fsType.In(0); !objType.ConvertibleTo(first) {
+			fs.Panicf("first parameter not convertible to expected type %s, got %s", objType, first)
 		}
 	}
 	// Allow the type check to fail if we can't get a value marshaler. This

--- a/glib/gasyncresult.go
+++ b/glib/gasyncresult.go
@@ -7,7 +7,6 @@ package glib
 import "C"
 import (
 	"errors"
-	"sync"
 	"unsafe"
 )
 
@@ -21,33 +20,7 @@ type IAsyncResult interface {
 }
 
 // AsyncReadyCallback is a representation of GAsyncReadyCallback
-type AsyncReadyCallback func(object *Object, res *AsyncResult, data uintptr)
-
-type asyncReadyCallbackData struct {
-	fn       AsyncReadyCallback
-	userData uintptr
-}
-
-var (
-	asyncReadyCallbackRegistry = struct {
-		sync.RWMutex
-		next int
-		m    map[int]asyncReadyCallbackData
-	}{
-		next: 1,
-		m:    make(map[int]asyncReadyCallbackData),
-	}
-)
-
-func registerAsyncReadyCallback(fn AsyncReadyCallback, userData uintptr) int {
-	asyncReadyCallbackRegistry.Lock()
-	id := asyncReadyCallbackRegistry.next
-	asyncReadyCallbackRegistry.next++
-	asyncReadyCallbackRegistry.m[id] = asyncReadyCallbackData{fn: fn, userData: userData}
-	asyncReadyCallbackRegistry.Unlock()
-
-	return id
-}
+type AsyncReadyCallback func(object *Object, res *AsyncResult)
 
 // AsyncResult is a representation of GIO's GAsyncResult.
 type AsyncResult struct {

--- a/glib/glib.go.h
+++ b/glib/glib.go.h
@@ -140,18 +140,19 @@ static GObjectClass *_g_object_get_class(GObject *object) {
 extern void goMarshal(GClosure *, GValue *, guint, GValue *, gpointer,
                       GValue *);
 
-static GClosure *_g_closure_new() {
+static inline GClosure *_g_closure_new() {
   GClosure *closure;
 
   closure = g_closure_new_simple(sizeof(GClosure), NULL);
   g_closure_set_marshal(closure, (GClosureMarshal)(goMarshal));
-  return (closure);
+  return closure;
 }
 
 extern void removeClosure(gpointer, GClosure *);
 
-static void _g_closure_add_finalize_notifier(GClosure *closure) {
-  g_closure_add_finalize_notifier(closure, NULL, removeClosure);
+static inline void _g_closure_add_finalize_notifier(GClosure *closure) {
+  g_closure_add_finalize_notifier(closure, NULL,
+                                  (GClosureNotify)(removeClosure));
 }
 
 static inline guint _g_signal_new(const gchar *name) {
@@ -183,7 +184,7 @@ static inline void set_string(char **strings, int n, char *str) {
 
 static inline gchar **next_gcharptr(gchar **s) { return (s + 1); }
 
-extern void goCompareDataFuncs(gconstpointer a, gconstpointer b,
+extern gint goCompareDataFuncs(gconstpointer a, gconstpointer b,
                                gpointer user_data);
 
 #endif

--- a/glib/glib_export.go
+++ b/glib/glib_export.go
@@ -3,32 +3,25 @@ package glib
 // #cgo pkg-config: gio-2.0
 // #include <gio/gio.h>
 import "C"
-import "unsafe"
+import (
+	"unsafe"
+
+	"github.com/gotk3/gotk3/internal/callback"
+)
 
 //export goAsyncReadyCallbacks
 func goAsyncReadyCallbacks(sourceObject *C.GObject, res *C.GAsyncResult, userData C.gpointer) {
-	id := int(uintptr(userData))
-
-	asyncReadyCallbackRegistry.Lock()
-	r := asyncReadyCallbackRegistry.m[id]
-	//delete(asyncReadyCallbackRegistry.m, id)
-	asyncReadyCallbackRegistry.Unlock()
-
 	var source *Object
 	if sourceObject != nil {
 		source = wrapObject(unsafe.Pointer(sourceObject))
 	}
 
-	r.fn(source, wrapAsyncResult(wrapObject(unsafe.Pointer(res))), r.userData)
+	fn := callback.Get(uintptr(userData)).(AsyncReadyCallback)
+	fn(source, wrapAsyncResult(wrapObject(unsafe.Pointer(res))))
 }
 
 //export goCompareDataFuncs
-func goCompareDataFuncs(a, b C.gconstpointer, userData C.gpointer) {
-	id := int(uintptr(userData))
-
-	compareDataFuncRegistry.RLock()
-	r := compareDataFuncRegistry.m[id]
-	compareDataFuncRegistry.RUnlock()
-
-	r.fn(uintptr(a), uintptr(b), r.userData)
+func goCompareDataFuncs(a, b C.gconstpointer, userData C.gpointer) C.gint {
+	fn := callback.Get(uintptr(userData)).(CompareDataFunc)
+	return C.gint(fn(uintptr(a), uintptr(b)))
 }

--- a/glib/glib_since_2_46.go
+++ b/glib/glib_since_2_46.go
@@ -11,19 +11,13 @@ package glib
 // #include "glib_since_2_44.go.h"
 // #include "glib_since_2_46.go.h"
 import "C"
+import "github.com/gotk3/gotk3/internal/callback"
 
 /*
  * GListStore
  */
 
 // Sort is a wrapper around g_list_store_sort().
-func (v *ListStore) Sort(compareFunc CompareDataFunc, userData ...interface{}) {
-	// TODO: figure out a way to determine when we can clean up
-	compareDataFuncRegistry.Lock()
-	id := compareDataFuncRegistry.next
-	compareDataFuncRegistry.next++
-	compareDataFuncRegistry.m[id] = compareDataFuncData{fn: compareFunc, userData: userData}
-	compareDataFuncRegistry.Unlock()
-
-	C._g_list_store_sort(v.native(), C.gpointer(uintptr(id)))
+func (v *ListStore) Sort(compareFunc CompareDataFunc) {
+	C._g_list_store_sort(v.native(), C.gpointer(callback.Assign(compareFunc)))
 }

--- a/glib/glistmodel.go
+++ b/glib/glistmodel.go
@@ -10,7 +10,11 @@ package glib
 // #include "glib.go.h"
 // #include "glib_since_2_44.go.h"
 import "C"
-import "unsafe"
+import (
+	"unsafe"
+
+	"github.com/gotk3/gotk3/internal/callback"
+)
 
 /*
  * GListModel
@@ -128,17 +132,9 @@ func (v *ListStore) Insert(position uint, item interface{}) {
 }
 
 // InsertSorted is a wrapper around g_list_store_insert_sorted().
-func (v *ListStore) InsertSorted(item interface{}, compareFunc CompareDataFunc, userData ...interface{}) {
-	// TODO: figure out a way to determine when we can clean up
-	compareDataFuncRegistry.Lock()
-	id := compareDataFuncRegistry.next
-	compareDataFuncRegistry.next++
-	compareDataFuncRegistry.m[id] = compareDataFuncData{fn: compareFunc, userData: userData}
-	compareDataFuncRegistry.Unlock()
-
+func (v *ListStore) InsertSorted(item interface{}, compareFunc CompareDataFunc) {
 	gItem := ToGObject(unsafe.Pointer(&item))
-
-	C._g_list_store_insert_sorted(v.native(), C.gpointer(gItem), C.gpointer(uintptr(id)))
+	C._g_list_store_insert_sorted(v.native(), C.gpointer(gItem), C.gpointer(callback.Assign(compareFunc)))
 }
 
 // Append is a wrapper around g_list_store_append().

--- a/glib/gpermission.go
+++ b/glib/gpermission.go
@@ -9,6 +9,8 @@ import "C"
 import (
 	"errors"
 	"unsafe"
+
+	"github.com/gotk3/gotk3/internal/callback"
 )
 
 // Permission is a representation of GIO's GPermission.
@@ -73,11 +75,8 @@ func (v *Permission) Acquire(cancellable *Cancellable) error {
 }
 
 // AcquireAsync is a wrapper around g_permission_acquire_async().
-func (v *Permission) AcquireAsync(cancellable *Cancellable, callback AsyncReadyCallback, userData uintptr) {
-
-	id := registerAsyncReadyCallback(callback, userData)
-
-	C._g_permission_acquire_async(v.native(), cancellable.native(), C.gpointer(uintptr(id)))
+func (v *Permission) AcquireAsync(cancellable *Cancellable, fn AsyncReadyCallback) {
+	C._g_permission_acquire_async(v.native(), cancellable.native(), C.gpointer(callback.Assign(fn)))
 }
 
 // AcquireFinish is a wrapper around g_permission_acquire_finish().
@@ -105,11 +104,8 @@ func (v *Permission) Release(cancellable *Cancellable) error {
 }
 
 // ReleaseAsync is a wrapper around g_permission_release_async().
-func (v *Permission) ReleaseAsync(cancellable *Cancellable, callback AsyncReadyCallback, userData uintptr) {
-
-	id := registerAsyncReadyCallback(callback, userData)
-
-	C._g_permission_release_async(v.native(), cancellable.native(), C.gpointer(uintptr(id)))
+func (v *Permission) ReleaseAsync(cancellable *Cancellable, fn AsyncReadyCallback) {
+	C._g_permission_release_async(v.native(), cancellable.native(), C.gpointer(callback.Assign(fn)))
 }
 
 // ReleaseFinish is a wrapper around g_permission_release_finish().

--- a/glib/list.go
+++ b/glib/list.go
@@ -5,7 +5,6 @@ package glib
 // #include "glib.go.h"
 import "C"
 import (
-	"sync"
 	"unsafe"
 )
 
@@ -173,20 +172,4 @@ func (v *List) FreeFull(fn func(item interface{})) {
 }
 
 // CompareDataFunc is a representation of GCompareDataFunc
-type CompareDataFunc func(a, b interface{}, userData ...interface{}) bool
-
-type compareDataFuncData struct {
-	fn       CompareDataFunc
-	userData []interface{}
-}
-
-var (
-	compareDataFuncRegistry = struct {
-		sync.RWMutex
-		next int
-		m    map[int]compareDataFuncData
-	}{
-		next: 1,
-		m:    make(map[int]compareDataFuncData),
-	}
-)
+type CompareDataFunc func(a, b uintptr) int

--- a/gtk/accel.go
+++ b/gtk/accel.go
@@ -126,7 +126,7 @@ func AccelGroupNew() (*AccelGroup, error) {
 
 // Connect is a wrapper around gtk_accel_group_connect().
 func (v *AccelGroup) Connect(key uint, mods gdk.ModifierType, flags AccelFlags, f interface{}) {
-	closure, _ := glib.ClosureNew(f)
+	closure := glib.ClosureNew(f)
 	cl := (*C.struct__GClosure)(unsafe.Pointer(closure))
 	C.gtk_accel_group_connect(
 		v.native(),
@@ -138,7 +138,7 @@ func (v *AccelGroup) Connect(key uint, mods gdk.ModifierType, flags AccelFlags, 
 
 // ConnectByPath is a wrapper around gtk_accel_group_connect_by_path().
 func (v *AccelGroup) ConnectByPath(path string, f interface{}) {
-	closure, _ := glib.ClosureNew(f)
+	closure := glib.ClosureNew(f)
 	cl := (*C.struct__GClosure)(unsafe.Pointer(closure))
 
 	cstr := C.CString(path)
@@ -152,7 +152,7 @@ func (v *AccelGroup) ConnectByPath(path string, f interface{}) {
 
 // Disconnect is a wrapper around gtk_accel_group_disconnect().
 func (v *AccelGroup) Disconnect(f interface{}) {
-	closure, _ := glib.ClosureNew(f)
+	closure := glib.ClosureNew(f)
 	cl := (*C.struct__GClosure)(unsafe.Pointer(closure))
 	C.gtk_accel_group_disconnect(v.native(), cl)
 }
@@ -179,7 +179,7 @@ func (v *AccelGroup) IsLocked() bool {
 
 // AccelGroupFromClosure is a wrapper around gtk_accel_group_from_accel_closure().
 func AccelGroupFromClosure(f interface{}) *AccelGroup {
-	closure, _ := glib.ClosureNew(f)
+	closure := glib.ClosureNew(f)
 	cl := (*C.struct__GClosure)(unsafe.Pointer(closure))
 	c := C.gtk_accel_group_from_accel_closure(cl)
 	if c == nil {

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -235,8 +235,8 @@ func init() {
  * Callback helpers
  */
 
-//export callbackDelete
-func callbackDelete(callbackID C.gpointer) {
+//export gotk3_callbackDelete
+func gotk3_callbackDelete(callbackID C.gpointer) {
 	callback.Delete(uintptr(callbackID))
 }
 

--- a/gtk/gtk.go.h
+++ b/gtk/gtk.go.h
@@ -22,8 +22,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-// callbackDelete satisfies the GDestroyNotify type.
-extern void callbackDelete(gpointer callback_id);
+// gotk3_callbackDelete satisfies the GDestroyNotify type.
+extern void gotk3_callbackDelete(gpointer callback_id);
 
 static GtkAboutDialog *toGtkAboutDialog(void *p) {
   return (GTK_ABOUT_DIALOG(p));
@@ -551,15 +551,26 @@ static inline void _gtk_builder_connect_signals_full(GtkBuilder *builder) {
       builder, (GtkBuilderConnectFunc)(goBuilderConnect), NULL);
 }
 
-extern gboolean goTreeModelFilterVisibleFuncs(GtkTreeModel *model,
-                                              GtkTreeIter *iter, gpointer data);
+extern gboolean goTreeViewSearchEqualFunc(GtkTreeModel *model, gint column,
+                                          gchar *key, GtkTreeIter *iter,
+                                          gpointer data);
+
+static inline void _gtk_tree_view_set_search_equal_func(GtkTreeView *tree_view,
+                                                        gpointer user_data) {
+  gtk_tree_view_set_search_equal_func(
+      tree_view, (GtkTreeViewSearchEqualFunc)(goTreeViewSearchEqualFunc),
+      user_data, (GDestroyNotify)(gotk3_callbackDelete));
+}
+
+extern gboolean goTreeModelFilterVisibleFunc(GtkTreeModel *model,
+                                             GtkTreeIter *iter, gpointer data);
 
 static inline void
 _gtk_tree_model_filter_set_visible_func(GtkTreeModelFilter *filter,
                                         gpointer user_data) {
   gtk_tree_model_filter_set_visible_func(
-      filter, (GtkTreeModelFilterVisibleFunc)(goTreeModelFilterVisibleFuncs),
-      user_data, (GDestroyNotify)(callbackDelete));
+      filter, (GtkTreeModelFilterVisibleFunc)(goTreeModelFilterVisibleFunc),
+      user_data, (GDestroyNotify)(gotk3_callbackDelete));
 }
 
 static inline void _gtk_text_buffer_insert_with_tag_by_name(
@@ -576,23 +587,23 @@ static inline void _gtk_text_buffer_insert_with_tag(GtkTextBuffer *buffer,
   gtk_text_buffer_insert_with_tags(buffer, iter, text, len, tag, NULL);
 }
 
-extern gint goTreeSortableSortFuncs(GtkTreeModel *model, GtkTreeIter *a,
-                                    GtkTreeIter *b, gpointer data);
+extern gint goTreeSortableSortFunc(GtkTreeModel *model, GtkTreeIter *a,
+                                   GtkTreeIter *b, gpointer data);
 
 static inline void _gtk_tree_sortable_set_sort_func(GtkTreeSortable *sortable,
                                                     gint sort_column_id,
                                                     gpointer user_data) {
   gtk_tree_sortable_set_sort_func(
       sortable, sort_column_id,
-      (GtkTreeIterCompareFunc)(goTreeSortableSortFuncs), user_data, NULL);
+      (GtkTreeIterCompareFunc)(goTreeSortableSortFunc), user_data, NULL);
 }
 
 static inline void
 _gtk_tree_sortable_set_default_sort_func(GtkTreeSortable *sortable,
                                          gpointer user_data) {
   gtk_tree_sortable_set_default_sort_func(
-      sortable, (GtkTreeIterCompareFunc)(goTreeSortableSortFuncs), user_data,
-      (GDestroyNotify)(callbackDelete));
+      sortable, (GtkTreeIterCompareFunc)(goTreeSortableSortFunc), user_data,
+      (GDestroyNotify)(gotk3_callbackDelete));
 }
 
 static GtkWidget *_gtk_dialog_new_with_buttons(const gchar *title,
@@ -636,5 +647,5 @@ _gtk_tree_selection_set_select_function(GtkTreeSelection *selection,
   gtk_tree_selection_set_select_function(
 
       selection, (GtkTreeSelectionFunc)(goTreeSelectionFunc), user_data,
-      (GDestroyNotify)(callbackDelete));
+      (GDestroyNotify)(gotk3_callbackDelete));
 }

--- a/gtk/gtk.go.h
+++ b/gtk/gtk.go.h
@@ -22,6 +22,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+// callbackDelete satisfies the GDestroyNotify type.
+extern void callbackDelete(gpointer callback_id);
+
 static GtkAboutDialog *toGtkAboutDialog(void *p) {
   return (GTK_ABOUT_DIALOG(p));
 }
@@ -548,33 +551,15 @@ static inline void _gtk_builder_connect_signals_full(GtkBuilder *builder) {
       builder, (GtkBuilderConnectFunc)(goBuilderConnect), NULL);
 }
 
-extern void goPrintSettings(gchar *key, gchar *value, gpointer user_data);
-
-static inline void _gtk_print_settings_foreach(GtkPrintSettings *ps,
-                                               gpointer user_data) {
-  gtk_print_settings_foreach(ps, (GtkPrintSettingsFunc)(goPrintSettings),
-                             user_data);
-}
-
-extern void goPageSetupDone(GtkPageSetup *setup, gpointer data);
-
-static inline void
-_gtk_print_run_page_setup_dialog_async(GtkWindow *parent, GtkPageSetup *setup,
-                                       GtkPrintSettings *settings,
-                                       gpointer data) {
-  gtk_print_run_page_setup_dialog_async(
-      parent, setup, settings, (GtkPageSetupDoneFunc)(goPageSetupDone), data);
-}
-
-extern gboolean goTreeModelFilterFuncs(GtkTreeModel *model, GtkTreeIter *iter,
-                                       gpointer data);
+extern gboolean goTreeModelFilterVisibleFuncs(GtkTreeModel *model,
+                                              GtkTreeIter *iter, gpointer data);
 
 static inline void
 _gtk_tree_model_filter_set_visible_func(GtkTreeModelFilter *filter,
                                         gpointer user_data) {
   gtk_tree_model_filter_set_visible_func(
-      filter, (GtkTreeModelFilterVisibleFunc)(goTreeModelFilterFuncs),
-      user_data, NULL);
+      filter, (GtkTreeModelFilterVisibleFunc)(goTreeModelFilterVisibleFuncs),
+      user_data, (GDestroyNotify)(callbackDelete));
 }
 
 static inline void _gtk_text_buffer_insert_with_tag_by_name(
@@ -607,7 +592,7 @@ _gtk_tree_sortable_set_default_sort_func(GtkTreeSortable *sortable,
                                          gpointer user_data) {
   gtk_tree_sortable_set_default_sort_func(
       sortable, (GtkTreeIterCompareFunc)(goTreeSortableSortFuncs), user_data,
-      NULL);
+      (GDestroyNotify)(callbackDelete));
 }
 
 static GtkWidget *_gtk_dialog_new_with_buttons(const gchar *title,
@@ -649,5 +634,7 @@ static inline void
 _gtk_tree_selection_set_select_function(GtkTreeSelection *selection,
                                         gpointer user_data) {
   gtk_tree_selection_set_select_function(
-      selection, (GtkTreeSelectionFunc)(goTreeSelectionFunc), user_data, NULL);
+
+      selection, (GtkTreeSelectionFunc)(goTreeSelectionFunc), user_data,
+      (GDestroyNotify)(callbackDelete));
 }

--- a/gtk/gtk_export_since_3_10.go
+++ b/gtk/gtk_export_since_3_10.go
@@ -8,37 +8,29 @@ import (
 	"unsafe"
 
 	"github.com/gotk3/gotk3/glib"
+	"github.com/gotk3/gotk3/internal/callback"
 )
 
 //export goListBoxFilterFuncs
 func goListBoxFilterFuncs(row *C.GtkListBoxRow, userData C.gpointer) C.gboolean {
-	id := int(uintptr(userData))
-
-	listBoxFilterFuncRegistry.RLock()
-	r := listBoxFilterFuncRegistry.m[id]
-	listBoxFilterFuncRegistry.RUnlock()
-
-	return gbool(r.fn(wrapListBoxRow(glib.Take(unsafe.Pointer(row))), r.userData))
+	fn := callback.Get(uintptr(userData)).(ListBoxFilterFunc)
+	return gbool(fn(wrapListBoxRow(glib.Take(unsafe.Pointer(row)))))
 }
 
 //export goListBoxHeaderFuncs
 func goListBoxHeaderFuncs(row *C.GtkListBoxRow, before *C.GtkListBoxRow, userData C.gpointer) {
-	id := int(uintptr(userData))
-
-	listBoxHeaderFuncRegistry.RLock()
-	r := listBoxHeaderFuncRegistry.m[id]
-	listBoxHeaderFuncRegistry.RUnlock()
-
-	r.fn(wrapListBoxRow(glib.Take(unsafe.Pointer(row))), wrapListBoxRow(glib.Take(unsafe.Pointer(before))), r.userData)
+	fn := callback.Get(uintptr(userData)).(ListBoxHeaderFunc)
+	fn(
+		wrapListBoxRow(glib.Take(unsafe.Pointer(row))),
+		wrapListBoxRow(glib.Take(unsafe.Pointer(before))),
+	)
 }
 
 //export goListBoxSortFuncs
 func goListBoxSortFuncs(row1 *C.GtkListBoxRow, row2 *C.GtkListBoxRow, userData C.gpointer) C.gint {
-	id := int(uintptr(userData))
-
-	listBoxSortFuncRegistry.RLock()
-	r := listBoxSortFuncRegistry.m[id]
-	listBoxSortFuncRegistry.RUnlock()
-
-	return C.gint(r.fn(wrapListBoxRow(glib.Take(unsafe.Pointer(row1))), wrapListBoxRow(glib.Take(unsafe.Pointer(row2))), r.userData))
+	fn := callback.Get(uintptr(userData)).(ListBoxSortFunc)
+	return C.gint(fn(
+		wrapListBoxRow(glib.Take(unsafe.Pointer(row1))),
+		wrapListBoxRow(glib.Take(unsafe.Pointer(row2))),
+	))
 }

--- a/gtk/gtk_export_since_3_14.go
+++ b/gtk/gtk_export_since_3_14.go
@@ -9,15 +9,11 @@ import (
 	"unsafe"
 
 	"github.com/gotk3/gotk3/glib"
+	"github.com/gotk3/gotk3/internal/callback"
 )
 
 //export goListBoxForEachFuncs
 func goListBoxForEachFuncs(box *C.GtkListBox, row *C.GtkListBoxRow, userData C.gpointer) {
-	id := int(uintptr(userData))
-
-	listBoxForeachFuncRegistry.RLock()
-	r := listBoxForeachFuncRegistry.m[id]
-	listBoxForeachFuncRegistry.RUnlock()
-
-	r.fn(wrapListBox(glib.Take(unsafe.Pointer(box))), wrapListBoxRow(glib.Take(unsafe.Pointer(row))), r.userData)
+	fn := callback.Get(uintptr(userData)).(ListBoxForeachFunc)
+	fn(wrapListBox(glib.Take(unsafe.Pointer(box))), wrapListBoxRow(glib.Take(unsafe.Pointer(row))))
 }

--- a/gtk/gtk_export_since_3_16.go
+++ b/gtk/gtk_export_since_3_16.go
@@ -5,14 +5,10 @@ package gtk
 
 // #include <gtk/gtk.h>
 import "C"
+import "github.com/gotk3/gotk3/internal/callback"
 
 //export goListBoxCreateWidgetFuncs
 func goListBoxCreateWidgetFuncs(item, userData C.gpointer) {
-	id := int(uintptr(userData))
-
-	listBoxCreateWidgetFuncRegistry.RLock()
-	r := listBoxCreateWidgetFuncRegistry.m[id]
-	listBoxCreateWidgetFuncRegistry.RUnlock()
-
-	r.fn(uintptr(item), r.userData)
+	fn := callback.Get(uintptr(userData)).(ListBoxCreateWidgetFunc)
+	fn(uintptr(item))
 }

--- a/gtk/gtk_since_3_10.go
+++ b/gtk/gtk_since_3_10.go
@@ -12,12 +12,12 @@ package gtk
 import "C"
 import (
 	"errors"
-	"sync"
 	"unsafe"
 
 	"github.com/gotk3/gotk3/cairo"
 	"github.com/gotk3/gotk3/gdk"
 	"github.com/gotk3/gotk3/glib"
+	"github.com/gotk3/gotk3/internal/callback"
 	"github.com/gotk3/gotk3/pango"
 )
 
@@ -462,96 +462,27 @@ func (v *ListBox) InvalidateSort() {
 }
 
 // ListBoxFilterFunc is a representation of GtkListBoxFilterFunc
-type ListBoxFilterFunc func(row *ListBoxRow, userData ...interface{}) bool
-
-type listBoxFilterFuncData struct {
-	fn       ListBoxFilterFunc
-	userData []interface{}
-}
-
-var (
-	listBoxFilterFuncRegistry = struct {
-		sync.RWMutex
-		next int
-		m    map[int]listBoxFilterFuncData
-	}{
-		next: 1,
-		m:    make(map[int]listBoxFilterFuncData),
-	}
-)
+type ListBoxFilterFunc func(row *ListBoxRow) bool
 
 // SetFilterFunc is a wrapper around gtk_list_box_set_filter_func
-func (v *ListBox) SetFilterFunc(fn ListBoxFilterFunc, userData ...interface{}) {
-	// TODO: figure out a way to determine when we can clean up
-	listBoxFilterFuncRegistry.Lock()
-	id := listBoxFilterFuncRegistry.next
-	listBoxFilterFuncRegistry.next++
-	listBoxFilterFuncRegistry.m[id] = listBoxFilterFuncData{fn: fn, userData: userData}
-	listBoxFilterFuncRegistry.Unlock()
-
-	C._gtk_list_box_set_filter_func(v.native(), C.gpointer(uintptr(id)))
+func (v *ListBox) SetFilterFunc(fn ListBoxFilterFunc) {
+	C._gtk_list_box_set_filter_func(v.native(), C.gpointer(callback.Assign(fn)))
 }
 
 // ListBoxHeaderFunc is a representation of GtkListBoxUpdateHeaderFunc
-type ListBoxHeaderFunc func(row *ListBoxRow, before *ListBoxRow, userData ...interface{})
-
-type listBoxHeaderFuncData struct {
-	fn       ListBoxHeaderFunc
-	userData []interface{}
-}
-
-var (
-	listBoxHeaderFuncRegistry = struct {
-		sync.RWMutex
-		next int
-		m    map[int]listBoxHeaderFuncData
-	}{
-		next: 1,
-		m:    make(map[int]listBoxHeaderFuncData),
-	}
-)
+type ListBoxHeaderFunc func(row *ListBoxRow, before *ListBoxRow)
 
 // SetHeaderFunc is a wrapper around gtk_list_box_set_header_func
-func (v *ListBox) SetHeaderFunc(fn ListBoxHeaderFunc, userData ...interface{}) {
-	// TODO: figure out a way to determine when we can clean up
-	listBoxHeaderFuncRegistry.Lock()
-	id := listBoxHeaderFuncRegistry.next
-	listBoxHeaderFuncRegistry.next++
-	listBoxHeaderFuncRegistry.m[id] = listBoxHeaderFuncData{fn: fn, userData: userData}
-	listBoxHeaderFuncRegistry.Unlock()
-
-	C._gtk_list_box_set_header_func(v.native(), C.gpointer(uintptr(id)))
+func (v *ListBox) SetHeaderFunc(fn ListBoxHeaderFunc) {
+	C._gtk_list_box_set_header_func(v.native(), C.gpointer(callback.Assign(fn)))
 }
 
 // ListBoxSortFunc is a representation of GtkListBoxSortFunc
-type ListBoxSortFunc func(row1 *ListBoxRow, row2 *ListBoxRow, userData ...interface{}) int
-
-type listBoxSortFuncData struct {
-	fn       ListBoxSortFunc
-	userData []interface{}
-}
-
-var (
-	listBoxSortFuncRegistry = struct {
-		sync.RWMutex
-		next int
-		m    map[int]listBoxSortFuncData
-	}{
-		next: 1,
-		m:    make(map[int]listBoxSortFuncData),
-	}
-)
+type ListBoxSortFunc func(row1 *ListBoxRow, row2 *ListBoxRow) int
 
 // SetSortFunc is a wrapper around gtk_list_box_set_sort_func
-func (v *ListBox) SetSortFunc(fn ListBoxSortFunc, userData ...interface{}) {
-	// TODO: figure out a way to determine when we can clean up
-	listBoxSortFuncRegistry.Lock()
-	id := listBoxSortFuncRegistry.next
-	listBoxSortFuncRegistry.next++
-	listBoxSortFuncRegistry.m[id] = listBoxSortFuncData{fn: fn, userData: userData}
-	listBoxSortFuncRegistry.Unlock()
-
-	C._gtk_list_box_set_sort_func(v.native(), C.gpointer(uintptr(id)))
+func (v *ListBox) SetSortFunc(fn ListBoxSortFunc) {
+	C._gtk_list_box_set_sort_func(v.native(), C.gpointer(callback.Assign(fn)))
 }
 
 // DragHighlightRow is a wrapper around gtk_list_box_drag_highlight_row()

--- a/gtk/gtk_since_3_10.go.h
+++ b/gtk/gtk_since_3_10.go.h
@@ -16,6 +16,9 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include "gtk.go.h" // for callbackDelete
+#include <stdlib.h>
+
 static GtkHeaderBar *toGtkHeaderBar(void *p) { return (GTK_HEADER_BAR(p)); }
 
 static GtkListBox *toGtkListBox(void *p) { return (GTK_LIST_BOX(p)); }
@@ -36,8 +39,9 @@ extern gboolean goListBoxFilterFuncs(GtkListBoxRow *row, gpointer user_data);
 
 static inline void _gtk_list_box_set_filter_func(GtkListBox *box,
                                                  gpointer user_data) {
-  gtk_list_box_set_filter_func(
-      box, (GtkListBoxFilterFunc)(goListBoxFilterFuncs), user_data, NULL);
+  gtk_list_box_set_filter_func(box,
+                               (GtkListBoxFilterFunc)(goListBoxFilterFuncs),
+                               user_data, (GDestroyNotify)(callbackDelete));
 }
 
 extern void goListBoxHeaderFuncs(GtkListBoxRow *row, GtkListBoxRow *before,
@@ -46,7 +50,8 @@ extern void goListBoxHeaderFuncs(GtkListBoxRow *row, GtkListBoxRow *before,
 static inline void _gtk_list_box_set_header_func(GtkListBox *box,
                                                  gpointer user_data) {
   gtk_list_box_set_header_func(
-      box, (GtkListBoxUpdateHeaderFunc)(goListBoxHeaderFuncs), user_data, NULL);
+      box, (GtkListBoxUpdateHeaderFunc)(goListBoxHeaderFuncs), user_data,
+      (GDestroyNotify)(callbackDelete));
 }
 
 extern gint goListBoxSortFuncs(GtkListBoxRow *row1, GtkListBoxRow *row2,
@@ -55,5 +60,5 @@ extern gint goListBoxSortFuncs(GtkListBoxRow *row1, GtkListBoxRow *row2,
 static inline void _gtk_list_box_set_sort_func(GtkListBox *box,
                                                gpointer user_data) {
   gtk_list_box_set_sort_func(box, (GtkListBoxSortFunc)(goListBoxSortFuncs),
-                             user_data, NULL);
+                             user_data, (GDestroyNotify)(callbackDelete));
 }

--- a/gtk/gtk_since_3_10.go.h
+++ b/gtk/gtk_since_3_10.go.h
@@ -16,7 +16,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include "gtk.go.h" // for callbackDelete
+#include "gtk.go.h" // for gotk3_callbackDelete
 #include <stdlib.h>
 
 static GtkHeaderBar *toGtkHeaderBar(void *p) { return (GTK_HEADER_BAR(p)); }
@@ -41,7 +41,7 @@ static inline void _gtk_list_box_set_filter_func(GtkListBox *box,
                                                  gpointer user_data) {
   gtk_list_box_set_filter_func(box,
                                (GtkListBoxFilterFunc)(goListBoxFilterFuncs),
-                               user_data, (GDestroyNotify)(callbackDelete));
+                               user_data, (GDestroyNotify)(gotk3_callbackDelete));
 }
 
 extern void goListBoxHeaderFuncs(GtkListBoxRow *row, GtkListBoxRow *before,
@@ -51,7 +51,7 @@ static inline void _gtk_list_box_set_header_func(GtkListBox *box,
                                                  gpointer user_data) {
   gtk_list_box_set_header_func(
       box, (GtkListBoxUpdateHeaderFunc)(goListBoxHeaderFuncs), user_data,
-      (GDestroyNotify)(callbackDelete));
+      (GDestroyNotify)(gotk3_callbackDelete));
 }
 
 extern gint goListBoxSortFuncs(GtkListBoxRow *row1, GtkListBoxRow *row2,
@@ -60,5 +60,5 @@ extern gint goListBoxSortFuncs(GtkListBoxRow *row1, GtkListBoxRow *row2,
 static inline void _gtk_list_box_set_sort_func(GtkListBox *box,
                                                gpointer user_data) {
   gtk_list_box_set_sort_func(box, (GtkListBoxSortFunc)(goListBoxSortFuncs),
-                             user_data, (GDestroyNotify)(callbackDelete));
+                             user_data, (GDestroyNotify)(gotk3_callbackDelete));
 }

--- a/gtk/gtk_since_3_16.go
+++ b/gtk/gtk_since_3_16.go
@@ -8,7 +8,6 @@ package gtk
 // #include "gtk_since_3_16.go.h"
 import "C"
 import (
-	"sync"
 	"unsafe"
 
 	"github.com/gotk3/gotk3/gdk"
@@ -114,23 +113,7 @@ func (v *Notebook) DetachTab(child IWidget) {
  */
 
 // ListBoxCreateWidgetFunc is a representation of GtkListBoxCreateWidgetFunc.
-type ListBoxCreateWidgetFunc func(item interface{}, userData ...interface{}) int
-
-type listBoxCreateWidgetFuncData struct {
-	fn       ListBoxCreateWidgetFunc
-	userData []interface{}
-}
-
-var (
-	listBoxCreateWidgetFuncRegistry = struct {
-		sync.RWMutex
-		next int
-		m    map[int]listBoxCreateWidgetFuncData
-	}{
-		next: 1,
-		m:    make(map[int]listBoxCreateWidgetFuncData),
-	}
-)
+type ListBoxCreateWidgetFunc func(item interface{}) int
 
 /*
  * GtkScrolledWindow

--- a/gtk/gtk_since_3_16.go.h
+++ b/gtk/gtk_since_3_16.go.h
@@ -18,7 +18,8 @@
 
 #pragma once
 
-#include <stdlib.h>
+#include "gtk.go.h"
+#include <stdlib.h> // for callbackDelete
 
 static GListModel *toGListModel(void *p) { return (G_LIST_MODEL(p)); }
 
@@ -42,5 +43,5 @@ static inline void _gtk_list_box_bind_model(GtkListBox *box, GListModel *model,
                                             gpointer user_data) {
   gtk_list_box_bind_model(
       box, model, (GtkListBoxCreateWidgetFunc)(goListBoxCreateWidgetFuncs),
-      user_data, NULL);
+      user_data, (GDestroyNotify)(callbackDelete));
 }

--- a/gtk/gtk_since_3_16.go.h
+++ b/gtk/gtk_since_3_16.go.h
@@ -19,7 +19,7 @@
 #pragma once
 
 #include "gtk.go.h"
-#include <stdlib.h> // for callbackDelete
+#include <stdlib.h> // for gotk3_callbackDelete
 
 static GListModel *toGListModel(void *p) { return (G_LIST_MODEL(p)); }
 
@@ -43,5 +43,5 @@ static inline void _gtk_list_box_bind_model(GtkListBox *box, GListModel *model,
                                             gpointer user_data) {
   gtk_list_box_bind_model(
       box, model, (GtkListBoxCreateWidgetFunc)(goListBoxCreateWidgetFuncs),
-      user_data, (GDestroyNotify)(callbackDelete));
+      user_data, (GDestroyNotify)(gotk3_callbackDelete));
 }

--- a/gtk/gtk_since_3_16_glib_2_44.go
+++ b/gtk/gtk_since_3_16_glib_2_44.go
@@ -11,17 +11,15 @@ import "C"
 import (
 	"unsafe"
 
+	"github.com/gotk3/gotk3/internal/callback"
 	"github.com/gotk3/gotk3/glib"
 )
 
 // BindModel is a wrapper around gtk_list_box_bind_model().
-func (v *ListBox) BindModel(listModel *glib.ListModel, createWidgetFunc ListBoxCreateWidgetFunc, userData ...interface{}) {
-	// TODO: figure out a way to determine when we can clean up
-	listBoxCreateWidgetFuncRegistry.Lock()
-	id := listBoxCreateWidgetFuncRegistry.next
-	listBoxCreateWidgetFuncRegistry.next++
-	listBoxCreateWidgetFuncRegistry.m[id] = listBoxCreateWidgetFuncData{fn: createWidgetFunc, userData: userData}
-	listBoxCreateWidgetFuncRegistry.Unlock()
-
-	C._gtk_list_box_bind_model(v.native(), C.toGListModel(unsafe.Pointer(listModel.Native())), C.gpointer(uintptr(id)))
+func (v *ListBox) BindModel(listModel *glib.ListModel, createWidgetFunc ListBoxCreateWidgetFunc) {
+	C._gtk_list_box_bind_model(
+		v.native(),
+		C.toGListModel(unsafe.Pointer(listModel.Native())),
+		C.gpointer(callback.Assign(createWidgetFunc)),
+	)
 }

--- a/gtk/gtk_since_3_8.go
+++ b/gtk/gtk_since_3_8.go
@@ -25,11 +25,6 @@ package gtk
 
 // #include <gtk/gtk.h>
 import "C"
-import (
-	"sync"
-
-	"github.com/gotk3/gotk3/gdk"
-)
 
 /*
  * Constants
@@ -38,27 +33,4 @@ import (
 const (
 	STATE_FLAG_DIR_LTR StateFlags = C.GTK_STATE_FLAG_DIR_LTR
 	STATE_FLAG_DIR_RTL StateFlags = C.GTK_STATE_FLAG_DIR_RTL
-)
-
-/*
- * GtkTickCallback
- */
-
-// TickCallback is a representation of GtkTickCallback
-type TickCallback func(widget *Widget, frameClock *gdk.FrameClock, userData ...interface{}) bool
-
-type tickCallbackData struct {
-	fn       TickCallback
-	userData []interface{}
-}
-
-var (
-	tickCallbackRegistry = struct {
-		sync.RWMutex
-		next int
-		m    map[int]tickCallbackData
-	}{
-		next: 1,
-		m:    make(map[int]tickCallbackData),
-	}
 )

--- a/gtk/print.go.h
+++ b/gtk/print.go.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern void goPrintSettings(gchar *key, gchar *value, gpointer user_data);
+
+static inline void _gtk_print_settings_foreach(GtkPrintSettings *ps,
+                                               gpointer user_data) {
+  gtk_print_settings_foreach(ps, (GtkPrintSettingsFunc)(goPrintSettings),
+                             user_data);
+}
+
+extern void goPageSetupDone(GtkPageSetup *setup, gpointer data);
+
+static inline void
+_gtk_print_run_page_setup_dialog_async(GtkWindow *parent, GtkPageSetup *setup,
+                                       GtkPrintSettings *settings,
+                                       gpointer data) {
+  gtk_print_run_page_setup_dialog_async(
+      parent, setup, settings, (GtkPageSetupDoneFunc)(goPageSetupDone), data);
+}

--- a/gtk/print_export.go
+++ b/gtk/print_export.go
@@ -1,0 +1,23 @@
+package gtk
+
+// #include <gtk/gtk.h>
+import "C"
+import (
+	"unsafe"
+
+	"github.com/gotk3/gotk3/glib"
+	"github.com/gotk3/gotk3/internal/callback"
+)
+
+//export goPageSetupDone
+func goPageSetupDone(setup *C.GtkPageSetup, data C.gpointer) {
+	// This callback is only used once, so we can clean up immediately
+	fn := callback.GetAndDelete(uintptr(data)).(PageSetupDoneCallback)
+	fn(wrapPageSetup(glib.Take(unsafe.Pointer(setup))))
+}
+
+//export goPrintSettings
+func goPrintSettings(key *C.gchar, value *C.gchar, userData C.gpointer) {
+	fn := callback.Get(uintptr(userData)).(PrintSettingsCallback)
+	fn(C.GoString((*C.char)(key)), C.GoString((*C.char)(value)))
+}

--- a/gtk/print_test.go
+++ b/gtk/print_test.go
@@ -48,7 +48,7 @@ func TestPrintSettings(t *testing.T) {
 	settings.Set("Key3", "String2")
 	settings.SetInt("Key4", 2)
 
-	settings.ForEach(func(key, value string, userData ...interface{}) {
+	settings.ForEach(func(key, value string) {
 	}, 0)
 }
 

--- a/gtk/widget_export_since_3_8.go
+++ b/gtk/widget_export_since_3_8.go
@@ -10,19 +10,14 @@ import (
 
 	"github.com/gotk3/gotk3/gdk"
 	"github.com/gotk3/gotk3/glib"
+	"github.com/gotk3/gotk3/internal/callback"
 )
 
 //export goTickCallbacks
 func goTickCallbacks(widget *C.GtkWidget, frameClock *C.GdkFrameClock, userData C.gpointer) C.gboolean {
-	id := int(uintptr(userData))
-
-	tickCallbackRegistry.RLock()
-	r := tickCallbackRegistry.m[id]
-	tickCallbackRegistry.RUnlock()
-
-	return gbool(r.fn(
+	fn := callback.Get(uintptr(userData)).(TickCallback)
+	return gbool(fn(
 		wrapWidget(glib.Take(unsafe.Pointer(widget))),
 		gdk.WrapFrameClock(unsafe.Pointer(frameClock)),
-		r.userData,
 	))
 }

--- a/gtk/widget_since_3_8.go.h
+++ b/gtk/widget_since_3_8.go.h
@@ -16,6 +16,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include "gtk.go.h" // for callbackDelete
 #include <stdlib.h>
 
 extern gboolean goTickCallbacks(GtkWidget *widget, GdkFrameClock *frame_clock,
@@ -24,5 +25,6 @@ extern gboolean goTickCallbacks(GtkWidget *widget, GdkFrameClock *frame_clock,
 static inline guint _gtk_widget_add_tick_callback(GtkWidget *widget,
                                                   gpointer user_data) {
   return gtk_widget_add_tick_callback(
-      widget, (GtkTickCallback)(goTickCallbacks), user_data, NULL);
+      widget, (GtkTickCallback)(goTickCallbacks), user_data,
+      (GDestroyNotify)(callbackDelete));
 }

--- a/gtk/widget_since_3_8.go.h
+++ b/gtk/widget_since_3_8.go.h
@@ -16,7 +16,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include "gtk.go.h" // for callbackDelete
+#include "gtk.go.h" // for gotk3_callbackDelete
 #include <stdlib.h>
 
 extern gboolean goTickCallbacks(GtkWidget *widget, GdkFrameClock *frame_clock,
@@ -26,5 +26,5 @@ static inline guint _gtk_widget_add_tick_callback(GtkWidget *widget,
                                                   gpointer user_data) {
   return gtk_widget_add_tick_callback(
       widget, (GtkTickCallback)(goTickCallbacks), user_data,
-      (GDestroyNotify)(callbackDelete));
+      (GDestroyNotify)(gotk3_callbackDelete));
 }

--- a/internal/callback/callback.go
+++ b/internal/callback/callback.go
@@ -1,0 +1,37 @@
+package callback
+
+import (
+	"sync"
+
+	"github.com/gotk3/gotk3/internal/slab"
+)
+
+var (
+	mutex    sync.RWMutex
+	registry slab.Slab
+)
+
+func Assign(callback interface{}) uintptr {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	return registry.Put(callback)
+}
+
+func Get(ptr uintptr) interface{} {
+	mutex.RLock()
+	defer mutex.RUnlock()
+
+	return registry.Get(ptr)
+}
+
+func Delete(ptr uintptr) {
+	GetAndDelete(ptr)
+}
+
+func GetAndDelete(ptr uintptr) interface{} {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	return registry.Pop(ptr)
+}

--- a/internal/closure/closure.go
+++ b/internal/closure/closure.go
@@ -1,0 +1,81 @@
+package closure
+
+import (
+	"sync"
+	"unsafe"
+)
+
+var (
+	closures = sync.Map{} // unsafe.Pointer(*GClosure) -> reflect.Value
+
+	// use a bi-directional map to allow lookup of the closure value from both
+	// the SourceHandle and the closure ID in constant time.
+	signalMu       sync.Mutex
+	signalClosures = map[uint]unsafe.Pointer{} // uint(SourceHandle) -> uintptr (closure key, callbackID)
+	closureSignals = map[unsafe.Pointer]uint{} // unsafe.Pointer(*GClosure) -> uint(SourceHandle)
+)
+
+// RegisterSignal registers the given signal handle to be associated with the
+// closure pointer. This association allows the closure to be removed as well
+// when the signal removal is requested from the user using DisconnectSignal.
+func RegisterSignal(handle uint, closure unsafe.Pointer) {
+	// Try and load the closure. Panic if we can't confirm that it is there.
+	if _, ok := closures.Load(closure); !ok {
+		panic("BUG: RegisterSignal called on invalid closure pointer")
+	}
+
+	signalMu.Lock()
+	defer signalMu.Unlock()
+
+	signalClosures[handle] = closure
+	closureSignals[closure] = handle
+}
+
+// DisconnectSignal removes both the signal and the closure associated with it
+// from the internal registry. Since this function will also remove the closure
+// itself from the internal registry, Gtk's disconnect functions should be
+// called first.
+func DisconnectSignal(handle uint) {
+	signalMu.Lock()
+	defer signalMu.Unlock()
+
+	closure, ok := signalClosures[handle]
+	if ok {
+		closures.Delete(closure)
+		delete(closureSignals, closure)
+		delete(signalClosures, handle)
+	}
+}
+
+// Assign assigns the given FuncStack to the given closure.
+func Assign(closure unsafe.Pointer, fs FuncStack) {
+	closures.Store(closure, fs)
+}
+
+// Get gets the reflect-value callback from the closure pointer.
+func Get(closure unsafe.Pointer) FuncStack {
+	v, ok := closures.Load(closure)
+	if ok {
+		return v.(FuncStack)
+	}
+	return zeroFuncStack
+}
+
+// Delete deletes the closure pointer from the registry while also checking for
+// any existing signal handler associated with the given callback ID. If a
+// signal handler is found, then its behavior is similar to DisconnectSignal.
+func Delete(closure unsafe.Pointer) {
+	funcStack := getAndDeleteClosure(closure)
+	if !funcStack.IsValid() {
+		return
+	}
+
+	signalMu.Lock()
+	defer signalMu.Unlock()
+
+	handle, ok := closureSignals[closure]
+	if ok {
+		delete(closureSignals, closure)
+		delete(signalClosures, handle)
+	}
+}

--- a/internal/closure/closure.go
+++ b/internal/closure/closure.go
@@ -19,10 +19,8 @@ var (
 // closure pointer. This association allows the closure to be removed as well
 // when the signal removal is requested from the user using DisconnectSignal.
 func RegisterSignal(handle uint, closure unsafe.Pointer) {
-	// Try and load the closure. Panic if we can't confirm that it is there.
-	if _, ok := closures.Load(closure); !ok {
-		panic("BUG: RegisterSignal called on invalid closure pointer")
-	}
+	// Safety check omitted until the race condition in glib/connect.go is
+	// fixed. Check that file for more info.
 
 	signalMu.Lock()
 	defer signalMu.Unlock()

--- a/internal/closure/closure_go_1_14.go
+++ b/internal/closure/closure_go_1_14.go
@@ -1,0 +1,14 @@
+// +build !go1.15
+
+package closure
+
+import "unsafe"
+
+func getAndDeleteClosure(closure unsafe.Pointer) FuncStack {
+	v, ok := closures.Load(closure)
+	if ok {
+		closures.Delete(closure)
+		return v.(FuncStack)
+	}
+	return zeroFuncStack
+}

--- a/internal/closure/closure_go_1_15.go
+++ b/internal/closure/closure_go_1_15.go
@@ -1,0 +1,13 @@
+// +build go1.15
+
+package closure
+
+import "unsafe"
+
+func getAndDeleteClosure(closure unsafe.Pointer) FuncStack {
+	v, ok := closures.LoadAndDelete(closure)
+	if ok {
+		return v.(FuncStack)
+	}
+	return zeroFuncStack
+}

--- a/internal/closure/funcstack.go
+++ b/internal/closure/funcstack.go
@@ -1,0 +1,74 @@
+package closure
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// FrameSize is the number of frames that FuncStack should trace back from.
+const FrameSize = 3
+
+// FuncStack wraps a function value and provides function frames containing the
+// caller trace for debugging.
+type FuncStack struct {
+	Func   reflect.Value
+	Frames []uintptr
+}
+
+var zeroFuncStack = FuncStack{}
+
+// NewFuncStack creates a new FuncStack. It panics if fn is not a function. The
+// given frameSkip is added 2, meaning the first frame from 0 will start from
+// the caller of NewFuncStack.
+func NewFuncStack(fn interface{}, frameSkip int) FuncStack {
+	// Create a reflect.Value from f.  This is called when the returned
+	// GClosure runs.
+	rf := reflect.ValueOf(fn)
+
+	// Closures can only be created from funcs.
+	if rf.Type().Kind() != reflect.Func {
+		panic("closure value is not a func")
+	}
+
+	frames := make([]uintptr, FrameSize)
+	frames = frames[:runtime.Callers(frameSkip+2, frames)]
+
+	return FuncStack{
+		Func:   rf,
+		Frames: frames,
+	}
+}
+
+// IsValid returns true if the given FuncStack is not a zero-value i.e.  valid.
+func (fs FuncStack) IsValid() bool {
+	return fs.Frames != nil
+}
+
+// Panicf panics with the given FuncStack printed to standard error.
+func (fs FuncStack) Panicf(msgf string, v ...interface{}) {
+	msg := strings.Builder{}
+	msg.WriteString("closure error: ")
+	fmt.Fprintf(&msg, msgf, v...)
+
+	msg.WriteString("\n\nClosure added at:")
+
+	frames := runtime.CallersFrames(fs.Frames)
+	for {
+		frame, more := frames.Next()
+		msg.WriteString("\n\t")
+		msg.WriteString(frame.Function)
+		msg.WriteString(" at ")
+		msg.WriteString(frame.File)
+		msg.WriteByte(':')
+		msg.WriteString(strconv.Itoa(frame.Line))
+
+		if !more {
+			break
+		}
+	}
+
+	panic(msg.String())
+}

--- a/internal/slab/slab.go
+++ b/internal/slab/slab.go
@@ -1,0 +1,52 @@
+package slab
+
+type slabEntry struct {
+	Value interface{}
+	Index uintptr
+}
+
+func (entry slabEntry) IsValid() bool {
+	return entry.Value != nil
+}
+
+// Slab is an implementation of the internal registry free list. A zero-value
+// instance is a valid instance. This data structure is not thread-safe.
+type Slab struct {
+	entries []slabEntry
+	free    uintptr
+}
+
+func (s *Slab) Put(entry interface{}) uintptr {
+	if s.free == uintptr(len(s.entries)) {
+		index := uintptr(len(s.entries))
+		s.entries = append(s.entries, slabEntry{entry, 0})
+		s.free++
+		return index
+	}
+
+	index := s.free
+
+	s.free = s.entries[index].Index
+	s.entries[index] = slabEntry{entry, 0}
+
+	return index
+}
+
+func (s *Slab) Get(i uintptr) interface{} {
+	// Perform bound check.
+	if i >= uintptr(len(s.entries)) {
+		return nil
+	}
+	// Perform validity check in case of invalid ID.
+	if entry := s.entries[i]; entry.IsValid() {
+		return entry.Value
+	}
+	return nil
+}
+
+func (s *Slab) Pop(i uintptr) interface{} {
+	popped := s.entries[i].Value
+	s.entries[i] = slabEntry{nil, s.free}
+	s.free = i
+	return popped
+}


### PR DESCRIPTION
### ~~Precaution~~

~~**I** would recommend merging this PR later, perhaps when a new major (0.x for v0?) `gotk3` release is planned, since these breaking changes are quite significant. Perhaps it's worth maintaining a second branch (regularly rebased with `master`) for people to slowly migrate over.~~

The aforementioned requirement of needing a first argument when using `Connect` has been changed to no longer requiring it, as not all scenarios require such a case, such as `win.Connect("destroy", gtk.MainQuit)`, and they do get annoying quickly over time.

---

This pull request introduces proper `GDestroyNotify` callbacks as well as cleaner closure and callback global registries to reduce (if not eliminate) memory leaks.

This pull request also introduces several breaking changes. Below lists those changes in undefined order:

- Connect, IdleAdd, TimeoutAdd and others in GLib no longer return an error.
- Any error with the function argument (type `interface{}`) is assumed to be programmer error and will therefore panic. GLib functions in C do not have nullable returns either, so the usual `nilPtrErr` does not apply, therefore all error returns are omitted.
- Old Func types for callback setters no longer force a variadic list of arguments in their parameters, as Go's closure abilities allow referencing values from outside.

This pull request also adds a small stack trace that occurs when any callback cannot be handled gracefully. This helps find bugs easier:

```
panic: closure error: callback should have the object parameter to avoid circular references

Closure added at:
	main.main.func2.1 at /tmp/img-leak/main.go:89
	runtime.goexit at /nix/store/4glm9a63mqk5v9cdmv2nzp1j92fw4102-go-1.15.6/share/go/src/runtime/asm_amd64.s:1374

goroutine 6 [running]:
github.com/gotk3/gotk3/internal/closure.FuncStack.Panicf(0x5c13e0, 0x660a38, 0x13, 0xc0000227e0, 0x2, 0x3, 0x65f801, 0x46, 0x0, 0x0, ...)
	/home/diamond/Scripts/gotk3/internal/closure/funcstack.go:73 +0xabf
github.com/gotk3/gotk3/glib.(*Object).connectClosure(0xc000010088, 0xc00000e100, 0x656783, 0x1, 0x5c13e0, 0x660a38, 0x0)
	/home/diamond/Scripts/gotk3/glib/connect.go:86 +0x405

```

This pull request resolves #685 but might break #507.

---

Below lists several tidbits that were convenient for me to add during the refactor:

- [x] `(*gtk.TreeView).SetSearchEqualFunc`
- [x] GLib utility functions e.g. `FormatSize{,Full}`, `SpacedPrimesClosest`, ...
- [ ] `GApplication` and `GDBusConnection` (low priority, can be a follow-up PR)