### PR TITLE
Solve GtkAccelKey issue with golang 1.16

### DIFF
--- a/gtk/accel.go
+++ b/gtk/accel.go
@@ -255,36 +255,13 @@ func AccelMapAddEntry(path string, key uint, mods gdk.ModifierType) {
 	C.gtk_accel_map_add_entry((*C.gchar)(cstr), C.guint(key), C.GdkModifierType(mods))
 }
 
-type AccelKey struct {
-	key   uint
-	mods  gdk.ModifierType
-	flags uint16
-}
+type AccelKey C.GtkAccelKey
 
-func (v *AccelKey) native() *C.struct__GtkAccelKey {
+func (v *AccelKey) native() *C.GtkAccelKey {
 	if v == nil {
 		return nil
 	}
-
-	var val C.struct__GtkAccelKey
-	val.accel_key = C.guint(v.key)
-	val.accel_mods = C.GdkModifierType(v.mods)
-	val.accel_flags = v.flags
-	return &val
-}
-
-func wrapAccelKey(obj *C.struct__GtkAccelKey) *AccelKey {
-	if obj == nil {
-		return nil
-	}
-
-	var v AccelKey
-
-	v.key = uint(obj.accel_key)
-	v.mods = gdk.ModifierType(obj.accel_mods)
-	v.flags = uint16(obj.accel_flags)
-
-	return &v
+	return (*C.GtkAccelKey)(v)
 }
 
 // AccelMapLookupEntry is a wrapper around gtk_accel_map_lookup_entry().
@@ -292,10 +269,10 @@ func AccelMapLookupEntry(path string) *AccelKey {
 	cstr := C.CString(path)
 	defer C.free(unsafe.Pointer(cstr))
 
-	var v *C.struct__GtkAccelKey
+	var v = new(AccelKey)
 
-	C.gtk_accel_map_lookup_entry((*C.gchar)(cstr), v)
-	return wrapAccelKey(v)
+	C.gtk_accel_map_lookup_entry((*C.gchar)(cstr), v.native())
+	return v
 }
 
 // AccelMapChangeEntry is a wrapper around gtk_accel_map_change_entry().


### PR DESCRIPTION
This PR fixes the problem with the GtkAccelKey declaration described below.
Its purpose is to help users, like me, who want to test future v1.16 functionality, while using the gotk3 library, and to facilitate discussion about this to make this solution the best it can be for everyone.

#### GtkAccelKey and Golang 1.16 issue
altered file: 'accel.go'

Golang 1.16 - Cgo changes [Go 1.16 Release Notes - The Go Programming Language](https://tip.golang.org/doc/go1.16#cgo):
The cgo tool will no longer try to translate C struct bitfields into Go struct fields, even if their size can be represented in Go. The order in which C bitfields appear in memory is implementation dependent, so in some cases the cgo tool produced results that were silently incorrect.

'C' struct definition:

```c
struct GtkAccelKey {
  guint           accel_key;
  GdkModifierType accel_mods;
  guint           accel_flags : 16;
};
```

Cgo compilation errors:

```bash
../../gotk3/gotk3/gtk/accel.go:264:5: val.accel_flags undefined (type _Ctype_struct__GtkAccelKey has no field or method accel_flags)
../../gotk3/gotk3/gtk/accel.go:273:22: obj.accel_flags undefined (type *_Ctype_struct__GtkAccelKey has no field or method accel_flags)
```

Solution:
Need new declaration for GtkAccelKey structure that does not explicitly access to 'accel_flags'.
'accel_flags' value remain accessible using bitwise operations.