### PR TITLE
add bindings to GtkMenu

### DIFF
--- a/gtk/menu.go
+++ b/gtk/menu.go
@@ -9,6 +9,8 @@ import "C"
 import (
 	"unsafe"
 
+	"github.com/gotk3/gotk3/gdk"
+
 	"github.com/gotk3/gotk3/glib"
 )
 
@@ -69,9 +71,39 @@ func MenuNew() (*Menu, error) {
 	return wrapMenu(glib.Take(unsafe.Pointer(c))), nil
 }
 
-// Popdown() is a wrapper around gtk_menu_popdown().
-func (v *Menu) Popdown() {
-	C.gtk_menu_popdown(v.native())
+// GtkMenuNewFromModel is a wrapper around gtk_menu_new_from_model().
+func GtkMenuNewFromModel(model *glib.MenuModel) (*Menu, error) {
+	c := C.gtk_menu_new_from_model(C.toGMenuModel(unsafe.Pointer(model.Native())))
+	if c == nil {
+		return nil, nilPtrErr
+	}
+	return wrapMenu(glib.Take(unsafe.Pointer(c))), nil
+}
+
+// SetScreen is a wrapper around gtk_menu_set_screen().
+func (v *Menu) SetScreen(screen *gdk.Screen) {
+	C.gtk_menu_set_screen(v.native(), (*C.GdkScreen)(unsafe.Pointer(screen.Native())))
+}
+
+// Attach is a wrapper around gtk_menu_attach().
+func (v *Menu) Attach(child IWidget, l, r, t, b uint) {
+	C.gtk_menu_attach(
+		v.native(),
+		child.toWidget(),
+		C.guint(l),
+		C.guint(r),
+		C.guint(t),
+		C.guint(b))
+}
+
+// SetMonitor() is a wrapper around gtk_menu_set_monitor().
+func (v *Menu) SetMonitor(monitor_num int) {
+	C.gtk_menu_set_monitor(v.native(), C.gint(monitor_num))
+}
+
+// GetMonitor() is a wrapper around gtk_menu_get_monitor().
+func (v *Menu) GetMonitor() int {
+	return int(C.gtk_menu_get_monitor(v.native()))
 }
 
 // ReorderChild() is a wrapper around gtk_menu_reorder_child().
@@ -88,3 +120,53 @@ func (v *Menu) SetReserveToggleSize(reserve bool) {
 func (v *Menu) GetReserveToggleSize() bool {
 	return gobool(C.gtk_menu_get_reserve_toggle_size(v.native()))
 }
+
+// Popdown() is a wrapper around gtk_menu_popdown().
+func (v *Menu) Popdown() {
+	C.gtk_menu_popdown(v.native())
+}
+
+// TODO
+/*
+gtk_menu_reposition () require 'GtkMenuPositionFunc' (according to its position function.)
+*/
+
+// GetActive() is a wrapper around gtk_menu_get_active().
+func (v *Menu) GetActive() (*Menu, error) {
+	c := C.gtk_menu_get_active(v.native())
+	if c == nil {
+		return nil, nilPtrErr
+	}
+	return wrapMenu(glib.Take(unsafe.Pointer(c))), nil
+}
+
+// SetActive() is a wrapper around gtk_menu_set_active().
+func (v *Menu) SetActive(index uint) {
+	C.gtk_menu_set_active(v.native(), C.guint(index))
+}
+
+// TODO
+/*
+void
+gtk_menu_attach_to_widget (GtkMenu *menu,
+                           GtkWidget *attach_widget,
+                           GtkMenuDetachFunc detacher);
+
+void
+gtk_menu_detach (GtkMenu *menu);
+*/
+
+// GetAttachWidget() is a wrapper around gtk_menu_get_attach_widget().
+func (v *Menu) GetAttachWidget() (IWidget, error) {
+	c := C.gtk_menu_get_attach_widget(v.native())
+	if c == nil {
+		return nil, nilPtrErr
+	}
+	return castWidget(c)
+}
+
+// TODO
+/*
+GList *
+gtk_menu_get_for_attach_widget (GtkWidget *widget);
+*/

--- a/gtk/menu.go
+++ b/gtk/menu.go
@@ -78,3 +78,13 @@ func (v *Menu) Popdown() {
 func (v *Menu) ReorderChild(child IWidget, position int) {
 	C.gtk_menu_reorder_child(v.native(), child.toWidget(), C.gint(position))
 }
+
+// SetReserveToggleSize() is a wrapper around gtk_menu_set_reserve_toggle_size().
+func (v *Menu) SetReserveToggleSize(reserve bool) {
+	C.gtk_menu_set_reserve_toggle_size(v.native(), gbool(reserve))
+}
+
+// GetReserveToggleSize() is a wrapper around gtk_menu_get_reserve_toggle_size().
+func (v *Menu) GetReserveToggleSize() bool {
+	return gobool(C.gtk_menu_get_reserve_toggle_size(v.native()))
+}

--- a/gtk/menu_since_3_22.go
+++ b/gtk/menu_since_3_22.go
@@ -11,14 +11,35 @@ import (
 	"github.com/gotk3/gotk3/gdk"
 )
 
-// PopupAtPointer() is a wrapper for gtk_menu_popup_at_pointer(), on older versions it uses PopupAtMouseCursor
-func (v *Menu) PopupAtPointer(triggerEvent *gdk.Event) {
-	e := (*C.GdkEvent)(unsafe.Pointer(triggerEvent.Native()))
-	C.gtk_menu_popup_at_pointer(v.native(), e)
+// PopupAtRect is a wrapper around gtk_menu_popup_at_rect().
+func (v *Menu) PopupAtRect(rect_window *gdk.Window,
+	rect *gdk.Rectangle, rect_anchor, menu_anchor gdk.Gravity,
+	trigger_event *gdk.Event) {
+
+	C.gtk_menu_popup_at_rect(
+		v.native(),
+		(*C.GdkWindow)(unsafe.Pointer(rect_window.Native())),
+		(*C.GdkRectangle)(unsafe.Pointer(&rect.GdkRectangle)),
+		C.GdkGravity(rect_anchor),
+		C.GdkGravity(menu_anchor),
+		(*C.GdkEvent)(unsafe.Pointer(trigger_event.Native())))
 }
 
 // PopupAtWidget() is a wrapper for gtk_menu_popup_at_widget()
 func (v *Menu) PopupAtWidget(widget IWidget, widgetAnchor gdk.Gravity, menuAnchor gdk.Gravity, triggerEvent *gdk.Event) {
 	e := (*C.GdkEvent)(unsafe.Pointer(triggerEvent.Native()))
 	C.gtk_menu_popup_at_widget(v.native(), widget.toWidget(), C.GdkGravity(widgetAnchor), C.GdkGravity(menuAnchor), e)
+}
+
+// PopupAtPointer() is a wrapper for gtk_menu_popup_at_pointer(), on older versions it uses PopupAtMouseCursor
+func (v *Menu) PopupAtPointer(triggerEvent *gdk.Event) {
+	e := (*C.GdkEvent)(unsafe.Pointer(triggerEvent.Native()))
+	C.gtk_menu_popup_at_pointer(v.native(), e)
+}
+
+// PlaceOnMonitor() is a wrapper around gtk_menu_place_on_monitor().
+func (v *Menu) PlaceOnMonitor(monitor *gdk.Monitor) {
+	C.gtk_menu_place_on_monitor(
+		v.native(),
+		(*C.GdkMonitor)(unsafe.Pointer(monitor.Native())))
 }


### PR DESCRIPTION
add:
gtk_menu_get_reserve_toggle_size()
gtk_menu_set_reserve_toggle_size()
gtk_menu_place_on_monitor()
gtk_menu_popup_at_rect()
gtk_menu_get_attach_widget()
gtk_menu_set_active()
gtk_menu_get_active()
gtk_menu_get_monitor()
gtk_menu_set_monitor()
gtk_menu_attach()
gtk_menu_set_screen()
gtk_menu_new_from_model()
