### PR TITLE
Adds bindings for gdk_pixbuf_new_from_resource() and gdk_pixbuf_new_from_resource_at_scale()

### DIFF
--- a/gdk/pixbuf.go
+++ b/gdk/pixbuf.go
@@ -178,7 +178,7 @@ func PixbufNewFromDataOnly(pixbufData []byte) (*Pixbuf, error) {
 }
 
 // PixbufNewFromResource is a wrapper around gdk_pixbuf_new_from_resource()
-func PixbufNewFromResource(resourcePath string) (*gdk.Pixbuf, error) {
+func PixbufNewFromResource(resourcePath string) (*Pixbuf, error) {
 	var gerr *C.GError
 
 	cstr := C.CString(resourcePath)
@@ -192,11 +192,11 @@ func PixbufNewFromResource(resourcePath string) (*gdk.Pixbuf, error) {
 	}
 
 	obj := glib.Take(unsafe.Pointer(c))
-	return &gdk.Pixbuf{obj}, nil
+	return &Pixbuf{obj}, nil
 }
 
 // PixbufNewFromResourceAtScale is a wrapper around gdk_pixbuf_new_from_resource_at_scale()
-func PixbufNewFromResourceAtScale(resourcePath string, width, height int, preserveAspectRatio bool) (*gdk.Pixbuf, error) {
+func PixbufNewFromResourceAtScale(resourcePath string, width, height int, preserveAspectRatio bool) (*Pixbuf, error) {
 	var gerr *C.GError
 
 	cstr := C.CString(resourcePath)
@@ -218,7 +218,7 @@ func PixbufNewFromResourceAtScale(resourcePath string, width, height int, preser
 	}
 
 	obj := glib.Take(unsafe.Pointer(c))
-	return &gdk.Pixbuf{obj}, nil
+	return &Pixbuf{obj}, nil
 }
 
 // TODO:

--- a/gdk/pixbuf.go
+++ b/gdk/pixbuf.go
@@ -177,6 +177,50 @@ func PixbufNewFromDataOnly(pixbufData []byte) (*Pixbuf, error) {
 	return pixbufLoader.WriteAndReturnPixbuf(pixbufData)
 }
 
+// PixbufNewFromResource is a wrapper around gdk_pixbuf_new_from_resource()
+func PixbufNewFromResource(resourcePath string) (*gdk.Pixbuf, error) {
+	var gerr *C.GError
+
+	cstr := C.CString(resourcePath)
+	defer C.free(unsafe.Pointer(cstr))
+
+	c := C.gdk_pixbuf_new_from_resource((*C.gchar)(cstr), &gerr)
+
+	if gerr != nil {
+		defer C.g_error_free(gerr)
+		return nil, errors.New(C.GoString(gerr.message))
+	}
+
+	obj := glib.Take(unsafe.Pointer(c))
+	return &gdk.Pixbuf{obj}, nil
+}
+
+// PixbufNewFromResourceAtScale is a wrapper around gdk_pixbuf_new_from_resource_at_scale()
+func PixbufNewFromResourceAtScale(resourcePath string, width, height int, preserveAspectRatio bool) (*gdk.Pixbuf, error) {
+	var gerr *C.GError
+
+	cstr := C.CString(resourcePath)
+	defer C.free(unsafe.Pointer(cstr))
+
+	cPreserveAspectRatio := gbool(presereAspectRatio)
+
+	c := C.gdk_pixbuf_new_from_resource_at_scale(
+		(*C.gchar)(cstr),
+		C.gint(width),
+		C.gint(height),
+		C.gboolean(cPreserveAspectRatio),
+		&gerr,
+	)
+
+	if gerr != nil {
+		defer C.g_error_free(gerr)
+		return nil, errors.New(C.GoString(gerr.message))
+	}
+
+	obj := glib.Take(unsafe.Pointer(c))
+	return &gdk.Pixbuf{obj}, nil
+}
+
 // TODO:
 // gdk_pixbuf_new_from_xpm_data().
 // gdk_pixbuf_new_subpixbuf()

--- a/gdk/pixbuf.go
+++ b/gdk/pixbuf.go
@@ -202,7 +202,7 @@ func PixbufNewFromResourceAtScale(resourcePath string, width, height int, preser
 	cstr := C.CString(resourcePath)
 	defer C.free(unsafe.Pointer(cstr))
 
-	cPreserveAspectRatio := gbool(presereAspectRatio)
+	cPreserveAspectRatio := gbool(preserveAspectRatio)
 
 	c := C.gdk_pixbuf_new_from_resource_at_scale(
 		(*C.gchar)(cstr),


### PR DESCRIPTION
# Added Bindings
* `gdk.PixbufNewFromResource()` => [gdk_pixbuf_new_from_resource()](https://developer.gnome.org/gdk-pixbuf/stable/gdk-pixbuf-File-Loading.html#gdk-pixbuf-new-from-resource)
* `gdk.PixbufNewFromResourceAtScale()` =>  [gdk_pixbuf_new_from_resource_at_scale()](https://developer.gnome.org/gdk-pixbuf/stable/gdk-pixbuf-File-Loading.html#gdk-pixbuf-new-from-resource-at-scale)