### PR TITLE
Adds binding for gtk_cell_layout_clear_attributes()

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -2244,6 +2244,11 @@ func (v *CellLayout) AddAttribute(cell ICellRenderer, attribute string, column i
 		(*C.gchar)(cstr), C.gint(column))
 }
 
+// ClearAttributes is a wrapper around gtk_cell_layout_clear_attributes()
+func (v *CellLayout) ClearAttributes(cell ICellRenderer) {
+	C.gtk_cell_layout_clear_attributes(v.native(), cell.toCellRenderer())
+}
+
 /*
  * GtkCellView
  */


### PR DESCRIPTION
# Added Bindings

* `(v *CellLayout) ClearAttributes()` => [`gtk_cell_layout_clear_attributes()`](https://developer.gnome.org/gtk3/stable/GtkCellLayout.html#gtk-cell-layout-clear-attributes)