### PR TITLE
Add build tag pango_1_42 for Pango

### DIFF
--- a/pango/pango-attributes.go
+++ b/pango/pango-attributes.go
@@ -187,13 +187,6 @@ func (v *Attribute) native() *C.PangoAttribute {
 	return (*C.PangoAttribute)(unsafe.Pointer(v.pangoAttribute))
 }
 
-func AttrInsertHyphensNew(insertHyphens bool) *Attribute {
-	c := C.pango_attr_insert_hyphens_new(gbool(insertHyphens))
-	attr := new(Attribute)
-	attr.pangoAttribute = c
-	return attr
-}
-
 /*
 //typedef gboolean (*PangoAttrFilterFunc) (PangoAttribute *attribute,
 //					 gpointer        user_data);

--- a/pango/pango-attributes_since_1_44.go
+++ b/pango/pango-attributes_since_1_44.go
@@ -1,0 +1,18 @@
+// +build !pango_1_42
+
+package pango
+
+// #include <pango/pango.h>
+// #include "pango.go.h"
+import "C"
+
+var (
+	ATTR_INSERT_HYPHENS AttrType = C.PANGO_ATTR_INSERT_HYPHENS
+)
+
+func AttrInsertHyphensNew(insertHyphens bool) *Attribute {
+	c := C.pango_attr_insert_hyphens_new(gbool(insertHyphens))
+	attr := new(Attribute)
+	attr.pangoAttribute = c
+	return attr
+}


### PR DESCRIPTION
This pull request adds the build tag `pango_1_42` that would omit `AttrInsertHyphensNew` to allow building on older Ubuntu systems with `go build -tags pango_1_42`.