### PR TITLE
fix crash in SetHeader if header is nil

### DIFF
--- a/gtk/gtk_since_3_10.go
+++ b/gtk/gtk_since_3_10.go
@@ -552,6 +552,10 @@ func (v *ListBoxRow) GetHeader() (IWidget, error) {
 
 // SetHeader is a wrapper around gtk_list_box_row_set_header().
 func (v *ListBoxRow) SetHeader(header IWidget) {
+	if header == nil {
+		C.gtk_list_box_row_set_header(v.native(), nil)
+		return
+	}
 	C.gtk_list_box_row_set_header(v.native(), header.toWidget())
 }
 


### PR DESCRIPTION
To remove a header from a ListBoxRow, SetHeader is called with header == nil.
However this results in a runtime error (nil pointer dereference).
I fixed it with this commit. However, from definition of toWidget() I see that header.toWidget() should actually return nil. Why does that not work? Is there any better way to fix it?