### PR TITLE
Adding missing 'GtkButtonBox' to gotk3 'WrapMap'

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -11749,6 +11749,7 @@ var WrapMap = map[string]WrapFn{
 	"GtkBin":                  wrapBin,
 	"GtkBox":                  wrapBox,
 	"GtkButton":               wrapButton,
+	"GtkButtonBox":            wrapButtonBox,
 	"GtkCalendar":             wrapCalendar,
 	"GtkCellLayout":           wrapCellLayout,
 	"GtkCellEditable":         wrapCellEditable,


### PR DESCRIPTION
###### altered file: gtk.go

### Adding missing 'GtkButtonBox' in gotk3 'WrapMap'

---

#### example of problem solved by this PR:

"unrecognized class name GtkButtonBox"
Appears when the '**castInternal**' function is used.

##### Practical aspect:

- Added a button in GtkDialogMessage.
- button.GetParent ()
- "unrecognized class name GtkButtonBox"