### PR TITLE
More performant {Idle,Timeout}Add

### DIFF
--- a/glib/connect.go
+++ b/glib/connect.go
@@ -136,7 +136,6 @@ func ClosureNew(f interface{}) *C.GClosure {
 // internals.
 func ClosureNewFunc(funcStack closure.FuncStack) *C.GClosure {
 	gclosure := C._g_closure_new()
-	C._g_closure_add_finalize_notifier(gclosure)
 	closure.Assign(unsafe.Pointer(gclosure), funcStack)
 
 	return gclosure

--- a/glib/glib.go.h
+++ b/glib/glib.go.h
@@ -137,22 +137,21 @@ static GObjectClass *_g_object_get_class(GObject *object) {
  * Closure support
  */
 
+extern void removeSourceFunc(gpointer data);
+extern gboolean sourceFunc(gpointer data);
+
 extern void goMarshal(GClosure *, GValue *, guint, GValue *, gpointer,
                       GValue *);
+extern void removeClosure(gpointer, GClosure *);
 
 static inline GClosure *_g_closure_new() {
   GClosure *closure;
 
   closure = g_closure_new_simple(sizeof(GClosure), NULL);
   g_closure_set_marshal(closure, (GClosureMarshal)(goMarshal));
-  return closure;
-}
-
-extern void removeClosure(gpointer, GClosure *);
-
-static inline void _g_closure_add_finalize_notifier(GClosure *closure) {
   g_closure_add_finalize_notifier(closure, NULL,
                                   (GClosureNotify)(removeClosure));
+  return closure;
 }
 
 static inline guint _g_signal_new(const gchar *name) {

--- a/glib/gmain_context.go
+++ b/glib/gmain_context.go
@@ -50,8 +50,8 @@ func (v *MainContext) FindSourceById(hdlSrc SourceHandle) *Source {
 }
 
 // Acquire is a wrapper around g_main_context_acquire().
-func (v *MainContext) Acquire() {
-	C.g_main_context_acquire(v.native())
+func (v *MainContext) Acquire() bool {
+	return gobool(C.g_main_context_acquire(v.native()))
 }
 
 // Release is a wrapper around g_main_context_release().


### PR DESCRIPTION
    More performant {Idle,Timeout}Add
    
    This commit changes the IdleAdd and TimeoutAdd functions to use the
    g_full functions instead of the GClosure and g_source_attach API.
    
    The reason for this change was because both of these removed APIs hog a
    lot of CPU time for weird reasons and will eventually lag behind after a
    long time of usage. The new functions don't have this issue at all.
    
    A type check cache is also implemented just for IdleAdd and TimeoutAdd
    functions, because these functions are potentially uesd for critical
    functionality and should therefore be fast if possible.
    
    glib.MainContext's Acquire method is also changed to return a boolean in
    accordance to what's put in the GLib Main Loop documentation.