### PR TITLE
Fix dangerous memory reference again.

### DIFF
--- a/glib/glib.go
+++ b/glib/glib.go
@@ -282,8 +282,6 @@ func goMarshal(
 		C.g_value_unset(retValue)
 		C.g_value_init(retValue, C.GType(t))
 		C.g_value_copy(g.native(), retValue)
-
-		*retValue = *g.native()
 	}
 }
 


### PR DESCRIPTION
The fix made in e5dd2587cdc1 and outlined in bug #727 seems to have been
accidentally re-introduced in commit cf79ce840c3f (presumably because of
a merge conflict).  The same reproducer in the bug report can be used to
trigger this issue and validate the fix in this commit.