### PR TITLE
Includes `stdlib.h` library in order to remove the `g_binding_get_sou…

### DIFF
--- a/glib/glib.go
+++ b/glib/glib.go
@@ -20,6 +20,7 @@ package glib
 
 // #cgo pkg-config: gio-2.0 glib-2.0 gobject-2.0
 // #include <gio/gio.h>
+// #include <stdlib.h>
 // #include <glib.h>
 // #include <glib-object.h>
 // #include "glib.go.h"


### PR DESCRIPTION
…rce` and `g_binding_get_target`deprecated warnings.

When deprecated functions exist, the warnings related to those messages are showing. We tracked this work in the following link: https://github.com/coyim/coyim/issues/746#issue-894682292