### PR TITLE
Build constraints for cairo packages should be based on cairo-naming,…

### DIFF
--- a/cairo/fontoptions_since_1_16.go
+++ b/cairo/fontoptions_since_1_16.go
@@ -1,4 +1,4 @@
-// +build !pango_1_10,!pango_1_12,!pango_1_14
+// +build !cairo_1_10,!cairo_1_12,!cairo_1_14
 
 package cairo
 


### PR DESCRIPTION
… not use pango-naming.

I used the wrong build-constraints in the previous commit. This commit changes to use `cairo_` instead of `pango_`.