### PR TITLE
Uses cairo tags instead of pango in fontoptions.

### DIFF
--- a/cairo/fontoptions_since_1_16.go
+++ b/cairo/fontoptions_since_1_16.go
@@ -1,4 +1,4 @@
-// +build !pango_1_10,!pango_1_12,!pango_1_14
+// +build !cairo_1_10,!cairo_1_12,!cairo_1_13,!cairo_1_13,!cairo_1_14,!cairo_1_15
 
 package cairo
 

--- a/cairo/fontoptions_since_1_16.go
+++ b/cairo/fontoptions_since_1_16.go
@@ -1,4 +1,4 @@
-// +build !cairo_1_10,!cairo_1_12,!cairo_1_13,!cairo_1_13,!cairo_1_14,!cairo_1_15
+// +build !cairo_1_10,!cairo_1_12,!cairo_1_13,!cairo_1_14,!cairo_1_15
 
 package cairo
 
@@ -24,5 +24,5 @@ func (o *FontOptions) SetVariations(variations string) {
 		defer C.free(unsafe.Pointer(cvariations))
 	}
 
-	C.cairo_font_options_set_variations(o.native, cvariations)
+	C.ds(o.native, cvariations)
 }


### PR DESCRIPTION
`cairo_font_options_get_variations` and `cairo_font_options_set_variations` are available since cairo 1.16