### PR TITLE
It turns out Cairo release numberings are only even on the patch numb…

### DIFF
--- a/cairo/fontoptions_since_1_16.go
+++ b/cairo/fontoptions_since_1_16.go
@@ -1,4 +1,4 @@
-// +build !cairo_1_10,!cairo_1_12,!cairo_1_14
+// +build !cairo_1_9,!cairo_1_10,!cairo_1_11,!cairo_1_12,!cairo_1_13,!cairo_1_14,!cairo_1_15
 
 package cairo
 


### PR DESCRIPTION
…er, not the minor number, so we neet to include more Cairo releases

The previous PR only covered even release numbers, but it seems Cairo releases are only even on the patch number, so this PR adds the missing cairo releases to improve the coverage for this file.