### PR TITLE
Fix finalizer bad thread interaction

### DIFF
--- a/cairo/canvas.go
+++ b/cairo/canvas.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"runtime"
 	"unsafe"
+
+	"github.com/gotk3/gotk3/glib"
 )
 
 // Context is a representation of Cairo's cairo_t.
@@ -57,7 +59,7 @@ func (v *Context) Close() {
 func Create(target *Surface) *Context {
 	c := C.cairo_create(target.native())
 	ctx := wrapContext(c)
-	runtime.SetFinalizer(ctx, (*Context).destroy)
+	runtime.SetFinalizer(ctx, func(v *Context) { glib.FinalizerStrategy(v.destroy) })
 	return ctx
 }
 
@@ -95,7 +97,7 @@ func (v *Context) GetTarget() *Surface {
 	c := C.cairo_get_target(v.native())
 	s := wrapSurface(c)
 	s.reference()
-	runtime.SetFinalizer(s, (*Surface).destroy)
+	runtime.SetFinalizer(s, func(v *Surface) { glib.FinalizerStrategy(v.destroy) })
 	return s
 }
 
@@ -122,7 +124,7 @@ func (v *Context) GetGroupTarget() *Surface {
 	c := C.cairo_get_group_target(v.native())
 	s := wrapSurface(c)
 	s.reference()
-	runtime.SetFinalizer(s, (*Surface).destroy)
+	runtime.SetFinalizer(s, func(v *Surface) { glib.FinalizerStrategy(v.destroy) })
 	return s
 }
 

--- a/cairo/fontoptions.go
+++ b/cairo/fontoptions.go
@@ -87,7 +87,7 @@ func CreateFontOptions() *FontOptions {
 	native := C.cairo_font_options_create()
 
 	opts := &FontOptions{native}
-	runtime.SetFinalizer(opts, (*FontOptions).destroy)
+	runtime.SetFinalizer(opts, func(v *FontOptions) { glib.FinalizerStrategy(v.destroy) })
 
 	return opts
 }
@@ -101,7 +101,7 @@ func (o *FontOptions) Copy() *FontOptions {
 	native := C.cairo_font_options_copy(o.native)
 
 	opts := &FontOptions{native}
-	runtime.SetFinalizer(opts, (*FontOptions).destroy)
+	runtime.SetFinalizer(opts, func(v *FontOptions) { glib.FinalizerStrategy(v.destroy) })
 
 	return opts
 }

--- a/cairo/pattern.go
+++ b/cairo/pattern.go
@@ -8,6 +8,8 @@ import "C"
 import (
 	"runtime"
 	"unsafe"
+
+	"github.com/gotk3/gotk3/glib"
 )
 
 //--------------------------------------------[ cairo_pattern_t  ==  Pattern ]--
@@ -71,7 +73,7 @@ func newPatternFromNative(patternNative *C.cairo_pattern_t) (*Pattern, error) {
 	if e != nil {
 		return nil, e
 	}
-	runtime.SetFinalizer(ptr, (*Pattern).destroy)
+	runtime.SetFinalizer(ptr, func(v *Pattern) { glib.FinalizerStrategy(v.destroy) })
 	return ptr, nil
 }
 

--- a/cairo/region.go
+++ b/cairo/region.go
@@ -112,7 +112,7 @@ func newRegionFromNative(regionNative *C.cairo_region_t) (*Region, error) {
 	if e != nil {
 		return nil, e
 	}
-	runtime.SetFinalizer(ptr, (*Region).destroy)
+	runtime.SetFinalizer(ptr, func(v *Region) { glib.FinalizerStrategy(v.destroy) })
 	return ptr, nil
 }
 

--- a/cairo/surface.go
+++ b/cairo/surface.go
@@ -9,6 +9,8 @@ import "C"
 import (
 	"runtime"
 	"unsafe"
+
+	"github.com/gotk3/gotk3/glib"
 )
 
 /*
@@ -47,7 +49,7 @@ func CreateImageSurfaceForData(data []byte, format Format, width, height, stride
 
 	s := wrapSurface(surfaceNative)
 
-	runtime.SetFinalizer(s, (*Surface).destroy)
+	runtime.SetFinalizer(s, func(v *Surface) { glib.FinalizerStrategy(v.destroy) })
 
 	return s, nil
 }
@@ -57,7 +59,7 @@ func CreateImageSurface(format Format, width, height int) *Surface {
 	c := C.cairo_image_surface_create(C.cairo_format_t(format),
 		C.int(width), C.int(height))
 	s := wrapSurface(c)
-	runtime.SetFinalizer(s, (*Surface).destroy)
+	runtime.SetFinalizer(s, func(v *Surface) { glib.FinalizerStrategy(v.destroy) })
 	return s
 }
 
@@ -75,7 +77,7 @@ func CreatePDFSurface(fileName string, width float64, height float64) (*Surface,
 
 	s := wrapSurface(surfaceNative)
 
-	runtime.SetFinalizer(s, (*Surface).destroy)
+	runtime.SetFinalizer(s, func(v *Surface) { glib.FinalizerStrategy(v.destroy) })
 
 	return s, nil
 }
@@ -114,7 +116,7 @@ func NewSurface(s uintptr, needsRef bool) *Surface {
 	if needsRef {
 		surface.reference()
 	}
-	runtime.SetFinalizer(surface, (*Surface).destroy)
+	runtime.SetFinalizer(surface, func(v *Surface) { glib.FinalizerStrategy(v.destroy) })
 	return surface
 }
 
@@ -133,7 +135,7 @@ func (v *Surface) CreateSimilar(content Content, width, height int) *Surface {
 	c := C.cairo_surface_create_similar(v.native(),
 		C.cairo_content_t(content), C.int(width), C.int(height))
 	s := wrapSurface(c)
-	runtime.SetFinalizer(s, (*Surface).destroy)
+	runtime.SetFinalizer(s, func(v *Surface) { glib.FinalizerStrategy(v.destroy) })
 	return s
 }
 
@@ -144,7 +146,7 @@ func (v *Surface) CreateForRectangle(x, y, width, height float64) *Surface {
 	c := C.cairo_surface_create_for_rectangle(v.native(), C.double(x),
 		C.double(y), C.double(width), C.double(height))
 	s := wrapSurface(c)
-	runtime.SetFinalizer(s, (*Surface).destroy)
+	runtime.SetFinalizer(s, func(v *Surface) { glib.FinalizerStrategy(v.destroy) })
 	return s
 }
 

--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -811,7 +811,7 @@ func (v *Display) GetEvent() (*Event, error) {
 
 	//The finalizer is not on the glib.Object but on the event.
 	e := &Event{c}
-	runtime.SetFinalizer(e, (*Event).free)
+	runtime.SetFinalizer(e, func(v *Event) { glib.FinalizerStrategy(v.free) })
 	return e, nil
 }
 
@@ -824,7 +824,7 @@ func (v *Display) PeekEvent() (*Event, error) {
 
 	//The finalizer is not on the glib.Object but on the event.
 	e := &Event{c}
-	runtime.SetFinalizer(e, (*Event).free)
+	runtime.SetFinalizer(e, func(v *Event) { glib.FinalizerStrategy(v.free) })
 	return e, nil
 }
 
@@ -1927,7 +1927,7 @@ func (c *RGBA) Copy() (*RGBA, error) {
 	}
 	obj := wrapRGBA(cRgba)
 
-	runtime.SetFinalizer(obj, (*RGBA).free)
+	runtime.SetFinalizer(obj, func(v *RGBA) { glib.FinalizerStrategy(v.free) })
 	return obj, nil
 }
 
@@ -2420,7 +2420,7 @@ func (v *Window) PixbufGetFromWindow(x, y, w, h int) (*Pixbuf, error) {
 	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
 	p := &Pixbuf{obj}
 	//obj.Ref()
-	runtime.SetFinalizer(p, func(_ interface{}) { obj.Unref() })
+	runtime.SetFinalizer(p, func(_ interface{}) { glib.FinalizerStrategy(obj.Unref) })
 	return p, nil
 }
 
@@ -2432,7 +2432,7 @@ func (v *Window) GetDevicePosition(d *Device) (*Window, int, int, ModifierType) 
 	underneathWindow := C.gdk_window_get_device_position(v.native(), d.native(), &x, &y, &mt)
 	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(underneathWindow))}
 	rw := &Window{obj}
-	runtime.SetFinalizer(rw, func(_ interface{}) { obj.Unref() })
+	runtime.SetFinalizer(rw, func(_ interface{}) { glib.FinalizerStrategy(obj.Unref) })
 	return rw, int(x), int(y), ModifierType(mt)
 }
 
@@ -2445,7 +2445,7 @@ func PixbufGetFromSurface(surface *cairo.Surface, src_x, src_y, width, height in
 	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
 	p := &Pixbuf{obj}
 	//obj.Ref()
-	runtime.SetFinalizer(p, func(_ interface{}) { obj.Unref() })
+	runtime.SetFinalizer(p, func(_ interface{}) { glib.FinalizerStrategy(obj.Unref) })
 	return p, nil
 }
 

--- a/gdk/gdk_deprecated_since_3_20.go
+++ b/gdk/gdk_deprecated_since_3_20.go
@@ -48,7 +48,7 @@ func (v *DeviceManager) ListDevices(tp DeviceType) *glib.List {
 		return &Device{&glib.Object{glib.ToGObject(ptr)}}
 	})
 	runtime.SetFinalizer(glist, func(glist *glib.List) {
-		glist.Free()
+		glib.FinalizerStrategy(glist.Free)
 	})
 	return glist
 }

--- a/gdk/gdk_since_3_10.go
+++ b/gdk/gdk_since_3_10.go
@@ -12,6 +12,7 @@ import (
 	"unsafe"
 
 	"github.com/gotk3/gotk3/cairo"
+	"github.com/gotk3/gotk3/glib"
 )
 
 // TODO:
@@ -44,7 +45,7 @@ func CairoSurfaceCreateFromPixbuf(pixbuf *Pixbuf, scale int, window *Window) (*c
 	}
 
 	surface := cairo.WrapSurface(uintptr(unsafe.Pointer(v)))
-	runtime.SetFinalizer(surface, (*cairo.Surface).Close)
+	runtime.SetFinalizer(surface, func(v *cairo.Surface) { glib.FinalizerStrategy(v.Close) })
 
 	return surface, nil
 }

--- a/gdk/pixbuf.go
+++ b/gdk/pixbuf.go
@@ -113,7 +113,7 @@ func PixbufNew(colorspace Colorspace, hasAlpha bool, bitsPerSample, width, heigh
 	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
 	p := &Pixbuf{obj}
 	//obj.Ref()
-	runtime.SetFinalizer(p, func(_ interface{}) { obj.Unref() })
+	runtime.SetFinalizer(p, func(_ interface{}) { glib.FinalizerStrategy(obj.Unref) })
 	return p, nil
 }
 
@@ -134,7 +134,7 @@ func PixbufNewFromFile(filename string) (*Pixbuf, error) {
 	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
 	p := &Pixbuf{obj}
 	//obj.Ref()
-	runtime.SetFinalizer(p, func(_ interface{}) { obj.Unref() })
+	runtime.SetFinalizer(p, func(_ interface{}) { glib.FinalizerStrategy(obj.Unref) })
 	return p, nil
 }
 
@@ -163,7 +163,7 @@ func PixbufNewFromData(pixbufData []byte, cs Colorspace, hasAlpha bool, bitsPerS
 	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
 	p := &Pixbuf{obj}
 	//obj.Ref()
-	runtime.SetFinalizer(p, func(_ interface{}) { obj.Unref() })
+	runtime.SetFinalizer(p, func(_ interface{}) { glib.FinalizerStrategy(obj.Unref) })
 
 	return p, nil
 }
@@ -235,7 +235,7 @@ func PixbufCopy(v *Pixbuf) (*Pixbuf, error) {
 	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
 	p := &Pixbuf{obj}
 	//obj.Ref()
-	runtime.SetFinalizer(p, func(_ interface{}) { obj.Unref() })
+	runtime.SetFinalizer(p, func(_ interface{}) { glib.FinalizerStrategy(obj.Unref) })
 	return p, nil
 }
 
@@ -279,7 +279,7 @@ func (v *Pixbuf) GetPixels() (channels []byte) {
 	// To make sure the slice doesn't outlive the Pixbuf, add a reference
 	v.Ref()
 	runtime.SetFinalizer(&channels, func(_ *[]byte) {
-		v.Unref()
+		glib.FinalizerStrategy(v.Unref)
 	})
 	return
 }
@@ -327,7 +327,7 @@ func (v *Pixbuf) ScaleSimple(destWidth, destHeight int, interpType InterpType) (
 	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
 	p := &Pixbuf{obj}
 	//obj.Ref()
-	runtime.SetFinalizer(p, func(_ interface{}) { obj.Unref() })
+	runtime.SetFinalizer(p, func(_ interface{}) { glib.FinalizerStrategy(obj.Unref) })
 	return p, nil
 }
 
@@ -388,7 +388,7 @@ func (v *Pixbuf) AddAlpha(substituteColor bool, r, g, b uint8) *Pixbuf {
 
 	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
 	p := &Pixbuf{obj}
-	runtime.SetFinalizer(p, func(_ interface{}) { obj.Unref() })
+	runtime.SetFinalizer(p, func(_ interface{}) { glib.FinalizerStrategy(obj.Unref) })
 
 	return p
 }
@@ -494,7 +494,7 @@ func (v *PixbufAnimation) GetStaticImage() *Pixbuf {
 	// Add a reference so the pixbuf doesn't outlive the parent pixbuf
 	// animation.
 	v.Ref()
-	runtime.SetFinalizer(p, func(*Pixbuf) { v.Unref() })
+	runtime.SetFinalizer(p, func(*Pixbuf) { glib.FinalizerStrategy(v.Unref) })
 
 	return p
 }
@@ -519,7 +519,7 @@ func PixbufAnimationNewFromFile(filename string) (*PixbufAnimation, error) {
 
 	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
 	p := &PixbufAnimation{obj}
-	runtime.SetFinalizer(p, func(_ interface{}) { obj.Unref() })
+	runtime.SetFinalizer(p, func(_ interface{}) { glib.FinalizerStrategy(obj.Unref) })
 	return p, nil
 }
 

--- a/gdk/pixbuf_since_2_12.go
+++ b/gdk/pixbuf_since_2_12.go
@@ -28,6 +28,6 @@ func (v *Pixbuf) ApplyEmbeddedOrientation() (*Pixbuf, error) {
 	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
 	p := &Pixbuf{obj}
 	//obj.Ref()
-	runtime.SetFinalizer(p, func(_ interface{}) { obj.Unref() })
+	runtime.SetFinalizer(p, func(_ interface{}) { glib.FinalizerStrategy(obj.Unref) })
 	return p, nil
 }

--- a/gdk/pixbuf_since_2_32.go
+++ b/gdk/pixbuf_since_2_32.go
@@ -40,7 +40,7 @@ func PixbufNewFromBytes(pixbufData []byte, cs Colorspace, hasAlpha bool, bitsPer
 	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
 	p := &Pixbuf{obj}
 	//obj.Ref()
-	runtime.SetFinalizer(p, func(_ interface{}) { obj.Unref() })
+	runtime.SetFinalizer(p, func(_ interface{}) { glib.FinalizerStrategy(obj.Unref) })
 
 	return p, nil
 }

--- a/gdk/pixbuf_since_2_4.go
+++ b/gdk/pixbuf_since_2_4.go
@@ -125,7 +125,7 @@ func PixbufNewFromFileAtSize(filename string, width, height int) (*Pixbuf, error
 	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
 	p := &Pixbuf{obj}
 	//obj.Ref()
-	runtime.SetFinalizer(p, func(_ interface{}) { obj.Unref() })
+	runtime.SetFinalizer(p, func(_ interface{}) { glib.FinalizerStrategy(obj.Unref) })
 	return p, nil
 }
 

--- a/gdk/pixbuf_since_2_6.go
+++ b/gdk/pixbuf_since_2_6.go
@@ -39,7 +39,7 @@ func PixbufNewFromFileAtScale(filename string, width, height int, preserveAspect
 	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
 	p := &Pixbuf{obj}
 	//obj.Ref()
-	runtime.SetFinalizer(p, func(_ interface{}) { obj.Unref() })
+	runtime.SetFinalizer(p, func(_ interface{}) { glib.FinalizerStrategy(obj.Unref) })
 	return p, nil
 }
 
@@ -55,7 +55,7 @@ func (v *Pixbuf) RotateSimple(angle PixbufRotation) (*Pixbuf, error) {
 	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
 	p := &Pixbuf{obj}
 	//obj.Ref()
-	runtime.SetFinalizer(p, func(_ interface{}) { obj.Unref() })
+	runtime.SetFinalizer(p, func(_ interface{}) { glib.FinalizerStrategy(obj.Unref) })
 	return p, nil
 }
 
@@ -69,6 +69,6 @@ func (v *Pixbuf) Flip(horizontal bool) (*Pixbuf, error) {
 	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
 	p := &Pixbuf{obj}
 	//obj.Ref()
-	runtime.SetFinalizer(p, func(_ interface{}) { obj.Unref() })
+	runtime.SetFinalizer(p, func(_ interface{}) { glib.FinalizerStrategy(obj.Unref) })
 	return p, nil
 }

--- a/glib/finalizers.go
+++ b/glib/finalizers.go
@@ -1,0 +1,14 @@
+package glib
+
+// Finalizer is a function that when called will finalize an object
+type Finalizer func()
+
+// FinalizerStrategy will be called by every runtime finalizer in gotk3
+// The simple version will just call the finalizer given as an argument
+// but in larger programs this might cause problems with the UI thread.
+// The FinalizerStrategy function will always be called in the goroutine that
+// `runtime.SetFinalizer` uses. It is a `var` to explicitly allow clients to
+// change the strategy to something more advanced.
+var FinalizerStrategy = func(f Finalizer) {
+	f()
+}

--- a/glib/gicon.go
+++ b/glib/gicon.go
@@ -101,7 +101,7 @@ func IconNewForString(str string) (*Icon, error) {
 	obj := &Object{ToGObject(unsafe.Pointer(c))}
 	i := &Icon{obj}
 
-	runtime.SetFinalizer(i, func(_ interface{}) { obj.Unref() })
+	runtime.SetFinalizer(i, func(_ interface{}) { FinalizerStrategy(obj.Unref) })
 	return i, nil
 }
 

--- a/glib/gvariant.go
+++ b/glib/gvariant.go
@@ -88,7 +88,7 @@ func takeVariant(p *C.GVariant) *Variant {
 		obj.Ref()
 	}
 
-	runtime.SetFinalizer(obj, (*Variant).Unref)
+	runtime.SetFinalizer(obj, func(v *Variant) { FinalizerStrategy(v.Unref) })
 	return obj
 }
 
@@ -234,7 +234,7 @@ func (v *Variant) GetVariant() *Variant {
 	// The returned value is returned with full ownership transfer,
 	// only Unref(), don't Ref().
 	obj := newVariant(c)
-	runtime.SetFinalizer(obj, (*Variant).Unref)
+	runtime.SetFinalizer(obj, func(v *Variant) { FinalizerStrategy(v.Unref) })
 	return obj
 }
 

--- a/glib/gvarianttype.go
+++ b/glib/gvarianttype.go
@@ -52,7 +52,7 @@ func takeVariantType(v *C.GVariantType) *VariantType {
 		return nil
 	}
 	obj := &VariantType{v}
-	runtime.SetFinalizer(obj, (*VariantType).Free)
+	runtime.SetFinalizer(obj, func(v *VariantType) { FinalizerStrategy(v.Free) })
 	return obj
 }
 

--- a/gtk/application.go
+++ b/gtk/application.go
@@ -165,8 +165,6 @@ func (v *Application) GetWindows() *glib.List {
 	glist.DataWrapper(func(ptr unsafe.Pointer) interface{} {
 		return wrapWindow(glib.Take(ptr))
 	})
-	runtime.SetFinalizer(glist, func(l *glib.List) {
-		l.Free()
-	})
+	runtime.SetFinalizer(glist, func(v *glib.List) { glib.FinalizerStrategy(v.Free) })
 	return glist
 }

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -3189,7 +3189,7 @@ func (v *Clipboard) WaitForContents(target gdk.Atom) (*SelectionData, error) {
 		return nil, nilPtrErr
 	}
 	p := &SelectionData{c}
-	runtime.SetFinalizer(p, (*SelectionData).free)
+	runtime.SetFinalizer(p, func(l *SelectionData) { glib.FinalizerStrategy(l.free) })
 	return p, nil
 }
 
@@ -4189,7 +4189,7 @@ func (v *Entry) GetIconGIcon(iconPos EntryIconPosition) (*glib.Icon, error) {
 	}
 	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
 	i := &glib.Icon{obj}
-	runtime.SetFinalizer(i, func(_ interface{}) { obj.Unref() })
+	runtime.SetFinalizer(i, func(_ interface{}) { glib.FinalizerStrategy(obj.Unref) })
 	return i, nil
 }
 
@@ -5835,7 +5835,7 @@ func (v *Image) GetGIcon() (*glib.Icon, IconSize, error) {
 	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(gicon))}
 	i := &glib.Icon{obj}
 
-	runtime.SetFinalizer(i, func(_ interface{}) { obj.Unref() })
+	runtime.SetFinalizer(i, func(_ interface{}) { glib.FinalizerStrategy(obj.Unref) })
 	return i, IconSize(*size), nil
 }
 
@@ -8612,7 +8612,7 @@ func (v *SelectionData) GetPixbuf() *gdk.Pixbuf {
 
 	obj := &glib.Object{glib.ToGObject(unsafe.Pointer(c))}
 	p := &gdk.Pixbuf{obj}
-	runtime.SetFinalizer(p, func(_ interface{}) { obj.Unref() })
+	runtime.SetFinalizer(p, func(_ interface{}) { glib.FinalizerStrategy(obj.Unref) })
 
 	return p
 }
@@ -9244,7 +9244,7 @@ func TargetEntryNew(target string, flags TargetFlags, info uint) (*TargetEntry, 
 	}
 	t := (*TargetEntry)(unsafe.Pointer(c))
 	// causes setFinilizer error
-	//	runtime.SetFinalizer(t, (*TargetEntry).free)
+	//  runtime.SetFinalizer(t, func(v *TargetEntry) { glib.FinalizerStrategy(v.free) })
 	return t, nil
 }
 
@@ -10522,7 +10522,7 @@ func (v *TreeIter) Copy() (*TreeIter, error) {
 		return nil, nilPtrErr
 	}
 	t := &TreeIter{*c}
-	runtime.SetFinalizer(t, (*TreeIter).free)
+	runtime.SetFinalizer(t, func(v *TreeIter) { glib.FinalizerStrategy(v.free) })
 	return t, nil
 }
 
@@ -10642,7 +10642,7 @@ func (v *TreeModel) GetPath(iter *TreeIter) (*TreePath, error) {
 		return nil, nilPtrErr
 	}
 	p := &TreePath{c}
-	runtime.SetFinalizer(p, (*TreePath).free)
+	runtime.SetFinalizer(p, func(v *TreePath) { glib.FinalizerStrategy(v.free) })
 	return p, nil
 }
 
@@ -10795,7 +10795,7 @@ func (v *TreeModelFilter) ConvertChildPathToPath(childPath *TreePath) *TreePath 
 		return nil
 	}
 	p := &TreePath{path}
-	runtime.SetFinalizer(p, (*TreePath).free)
+	runtime.SetFinalizer(p, func(v *TreePath) { glib.FinalizerStrategy(v.free) })
 	return p
 }
 
@@ -10822,7 +10822,7 @@ func (v *TreeModelFilter) ConvertPathToChildPath(filterPath *TreePath) *TreePath
 		return nil
 	}
 	p := &TreePath{path}
-	runtime.SetFinalizer(p, (*TreePath).free)
+	runtime.SetFinalizer(p, func(v *TreePath) { glib.FinalizerStrategy(v.free) })
 	return p
 }
 
@@ -10919,7 +10919,7 @@ func TreePathNewFromString(path string) (*TreePath, error) {
 		return nil, nilPtrErr
 	}
 	t := &TreePath{c}
-	runtime.SetFinalizer(t, (*TreePath).free)
+	runtime.SetFinalizer(t, func(v *TreePath) { glib.FinalizerStrategy(v.free) })
 	return t, nil
 }
 
@@ -10945,7 +10945,7 @@ func TreePathNewFirst() (*TreePath, error) {
 		return nil, nilPtrErr
 	}
 	t := &TreePath{c}
-	runtime.SetFinalizer(t, (*TreePath).free)
+	runtime.SetFinalizer(t, func(v *TreePath) { glib.FinalizerStrategy(v.free) })
 	return t, nil
 }
 
@@ -10971,7 +10971,7 @@ func (v *TreePath) Copy() (*TreePath, error) {
 		return nil, nilPtrErr
 	}
 	t := &TreePath{c}
-	runtime.SetFinalizer(t, (*TreePath).free)
+	runtime.SetFinalizer(t, func(v *TreePath) { glib.FinalizerStrategy(v.free) })
 	return t, nil
 }
 
@@ -11057,9 +11057,11 @@ func (v *TreeSelection) GetSelectedRows(model ITreeModel) *glib.List {
 		return &TreePath{(*C.GtkTreePath)(ptr)}
 	})
 	runtime.SetFinalizer(glist, func(glist *glib.List) {
-		glist.FreeFull(func(item interface{}) {
-			path := item.(*TreePath)
-			C.gtk_tree_path_free(path.GtkTreePath)
+		glib.FinalizerStrategy(func() {
+			glist.FreeFull(func(item interface{}) {
+				path := item.(*TreePath)
+				C.gtk_tree_path_free(path.GtkTreePath)
+			})
 		})
 	})
 
@@ -11169,7 +11171,7 @@ func TreeRowReferenceNew(model *TreeModel, path *TreePath) (*TreeRowReference, e
 		return nil, nilPtrErr
 	}
 	r := &TreeRowReference{c}
-	runtime.SetFinalizer(r, (*TreeRowReference).free)
+	runtime.SetFinalizer(r, func(v *TreeRowReference) { glib.FinalizerStrategy(v.free) })
 	return r, nil
 }
 
@@ -11180,7 +11182,7 @@ func (v *TreeRowReference) GetPath() *TreePath {
 		return nil
 	}
 	t := &TreePath{c}
-	runtime.SetFinalizer(t, (*TreePath).free)
+	runtime.SetFinalizer(t, func(v *TreePath) { glib.FinalizerStrategy(v.free) })
 	return t
 }
 
@@ -11360,7 +11362,7 @@ func (v *TreeModelSort) ConvertChildPathToPath(childPath *TreePath) *TreePath {
 		return nil
 	}
 	p := &TreePath{path}
-	runtime.SetFinalizer(p, (*TreePath).free)
+	runtime.SetFinalizer(p, func(v *TreePath) { glib.FinalizerStrategy(v.free) })
 	return p
 }
 
@@ -11379,7 +11381,7 @@ func (v *TreeModelSort) ConvertPathToChildPath(sortPath *TreePath) *TreePath {
 		return nil
 	}
 	p := &TreePath{path}
-	runtime.SetFinalizer(p, (*TreePath).free)
+	runtime.SetFinalizer(p, func(v *TreePath) { glib.FinalizerStrategy(v.free) })
 	return p
 }
 

--- a/gtk/gtk_since_3_12.go
+++ b/gtk/gtk_since_3_12.go
@@ -569,6 +569,6 @@ func TreePathNewFromIndicesv(indices []int) (*TreePath, error) {
 		return nil, nilPtrErr
 	}
 	t := &TreePath{c}
-	runtime.SetFinalizer(t, (*TreePath).free)
+	runtime.SetFinalizer(t, func(l *TreePath) { glib.FinalizerStrategy(l.free) })
 	return t, nil
 }

--- a/gtk/icon_view.go
+++ b/gtk/icon_view.go
@@ -125,7 +125,7 @@ func (v *IconView) GetPathAtPos(x, y int) *TreePath {
 
 	if cpath != nil {
 		path = &TreePath{cpath}
-		runtime.SetFinalizer(path, (*TreePath).free)
+		runtime.SetFinalizer(path, func(v *TreePath) { glib.FinalizerStrategy(v.free) })
 	}
 
 	return path
@@ -144,7 +144,7 @@ func (v *IconView) GetItemAtPos(x, y int) (*TreePath, *CellRenderer) {
 
 	if cpath != nil {
 		path = &TreePath{cpath}
-		runtime.SetFinalizer(path, (*TreePath).free)
+		runtime.SetFinalizer(path, func(v *TreePath) { glib.FinalizerStrategy(v.free) })
 	}
 
 	if ccell != nil {
@@ -181,7 +181,7 @@ func (v *IconView) GetCursor() (*TreePath, *CellRenderer) {
 
 	if cpath != nil {
 		path = &TreePath{cpath}
-		runtime.SetFinalizer(path, (*TreePath).free)
+		runtime.SetFinalizer(path, func(v *TreePath) { glib.FinalizerStrategy(v.free) })
 	}
 
 	if ccell != nil {
@@ -331,9 +331,11 @@ func (v *IconView) GetSelectedItems() *glib.List {
 		return &TreePath{(*C.GtkTreePath)(ptr)}
 	})
 	runtime.SetFinalizer(glist, func(glist *glib.List) {
-		glist.FreeFull(func(item interface{}) {
-			path := item.(*TreePath)
-			C.gtk_tree_path_free(path.GtkTreePath)
+		glib.FinalizerStrategy(func() {
+			glist.FreeFull(func(item interface{}) {
+				path := item.(*TreePath)
+				C.gtk_tree_path_free(path.GtkTreePath)
+			})
 		})
 	})
 
@@ -372,12 +374,12 @@ func (v *IconView) GetVisibleRange() (*TreePath, *TreePath) {
 
 	if cpathStart != nil {
 		pathStart = &TreePath{cpathStart}
-		runtime.SetFinalizer(pathStart, (*TreePath).free)
+		runtime.SetFinalizer(pathStart, func(v *TreePath) { glib.FinalizerStrategy(v.free) })
 	}
 
 	if cpathEnd != nil {
 		pathEnd = &TreePath{cpathEnd}
-		runtime.SetFinalizer(pathEnd, (*TreePath).free)
+		runtime.SetFinalizer(pathEnd, func(v *TreePath) { glib.FinalizerStrategy(v.free) })
 	}
 
 	return pathStart, pathEnd
@@ -423,12 +425,12 @@ func (v *IconView) GetTooltipContext(x, y int, keyboardTip bool) (*TreeModel, *T
 
 	if cpath != nil {
 		path = &TreePath{cpath}
-		runtime.SetFinalizer(path, (*TreePath).free)
+		runtime.SetFinalizer(path, func(v *TreePath) { glib.FinalizerStrategy(v.free) })
 	}
 
 	if citer != nil {
 		iter = &TreeIter{*citer}
-		runtime.SetFinalizer(iter, (*TreeIter).free)
+		runtime.SetFinalizer(iter, func(v *TreeIter) { glib.FinalizerStrategy(v.free) })
 	}
 
 	return model, path, iter

--- a/gtk/print.go
+++ b/gtk/print.go
@@ -291,7 +291,7 @@ func (ps *PageSetup) SetOrientation(orientation PageOrientation) {
 func (ps *PageSetup) GetPaperSize() *PaperSize {
 	c := C.gtk_page_setup_get_paper_size(ps.native())
 	p := &PaperSize{c}
-	runtime.SetFinalizer(p, (*PaperSize).free)
+	runtime.SetFinalizer(p, func(v *PaperSize) { glib.FinalizerStrategy(v.free) })
 	return p
 }
 
@@ -471,7 +471,7 @@ func PaperSizeNew(name string) (*PaperSize, error) {
 	}
 
 	t := &PaperSize{c}
-	runtime.SetFinalizer(t, (*PaperSize).free)
+	runtime.SetFinalizer(t, func(v *PaperSize) { glib.FinalizerStrategy(v.free) })
 	return t, nil
 }
 
@@ -487,7 +487,7 @@ func PaperSizeNewFromPPD(name, displayName string, width, height float64) (*Pape
 		return nil, nilPtrErr
 	}
 	t := &PaperSize{c}
-	runtime.SetFinalizer(t, (*PaperSize).free)
+	runtime.SetFinalizer(t, func(v *PaperSize) { glib.FinalizerStrategy(v.free) })
 	return t, nil
 }
 
@@ -503,7 +503,7 @@ func PaperSizeNewCustom(name, displayName string, width, height float64, unit Un
 		return nil, nilPtrErr
 	}
 	t := &PaperSize{c}
-	runtime.SetFinalizer(t, (*PaperSize).free)
+	runtime.SetFinalizer(t, func(v *PaperSize) { glib.FinalizerStrategy(v.free) })
 	return t, nil
 }
 
@@ -514,7 +514,7 @@ func (ps *PaperSize) Copy() (*PaperSize, error) {
 		return nil, nilPtrErr
 	}
 	t := &PaperSize{c}
-	runtime.SetFinalizer(t, (*PaperSize).free)
+	runtime.SetFinalizer(t, func(v *PaperSize) { glib.FinalizerStrategy(v.free) })
 	return t, nil
 }
 
@@ -542,9 +542,11 @@ func PaperSizeGetPaperSizes(includeCustom bool) *glib.List {
 	})
 
 	runtime.SetFinalizer(glist, func(glist *glib.List) {
-		glist.FreeFull(func(item interface{}) {
-			ps := item.(*PaperSize)
-			C.gtk_paper_size_free(ps.GtkPaperSize)
+		glib.FinalizerStrategy(func() {
+			glist.FreeFull(func(item interface{}) {
+				ps := item.(*PaperSize)
+				C.gtk_paper_size_free(ps.GtkPaperSize)
+			})
 		})
 	})
 
@@ -1294,7 +1296,7 @@ func (ps *PrintSettings) GetPaperSize() (*PaperSize, error) {
 		return nil, nilPtrErr
 	}
 	p := &PaperSize{c}
-	runtime.SetFinalizer(p, (*PaperSize).free)
+	runtime.SetFinalizer(p, func(v *PaperSize) { glib.FinalizerStrategy(v.free) })
 	return p, nil
 }
 

--- a/gtk/print_since_3_16.go
+++ b/gtk/print_since_3_16.go
@@ -10,6 +10,8 @@ import "C"
 import (
 	"runtime"
 	"unsafe"
+
+	"github.com/gotk3/gotk3/glib"
 )
 
 // PaperSizeNewFromIpp is a wrapper around gtk_paper_size_new_from_ipp().
@@ -23,7 +25,7 @@ func PaperSizeNewFromIPP(name string, width, height float64) (*PaperSize, error)
 	}
 
 	t := &PaperSize{c}
-	runtime.SetFinalizer(t, (*PaperSize).free)
+	runtime.SetFinalizer(t, func(v *PaperSize) { glib.FinalizerStrategy(v.free) })
 	return t, nil
 }
 

--- a/gtk/text_view.go
+++ b/gtk/text_view.go
@@ -246,7 +246,7 @@ func (v *TextView) GetTabs() (*pango.TabArray, error) {
 		return nil, nilPtrErr
 	}
 	ta := pango.WrapTabArray(uintptr(unsafe.Pointer(c)))
-	runtime.SetFinalizer(ta, (*pango.TabArray).Free)
+	runtime.SetFinalizer(ta, func(v *pango.TabArray) { glib.FinalizerStrategy(v.Free) })
 	return ta, nil
 }
 

--- a/gtk/tree_view.go
+++ b/gtk/tree_view.go
@@ -121,7 +121,7 @@ func (v *TreeView) GetPathAtPos(x, y int) (*TreePath, *TreeViewColumn, int, int,
 
 	if cpath != nil {
 		path = &TreePath{cpath}
-		runtime.SetFinalizer(path, (*TreePath).free)
+		runtime.SetFinalizer(path, func(v *TreePath) { glib.FinalizerStrategy(v.free) })
 	}
 	if ccol != nil {
 		column = wrapTreeViewColumn(glib.Take(unsafe.Pointer(ccol)))
@@ -237,9 +237,7 @@ func (v *TreeView) GetColumns() *glib.List {
 	list.DataWrapper(func(ptr unsafe.Pointer) interface{} {
 		return wrapTreeViewColumn(glib.Take(unsafe.Pointer(ptr)))
 	})
-	runtime.SetFinalizer(list, func(glist *glib.List) {
-		glist.Free()
-	})
+	runtime.SetFinalizer(list, func(glist *glib.List) { glib.FinalizerStrategy(glist.Free) })
 
 	return list
 }
@@ -287,7 +285,7 @@ func (v *TreeView) GetCursor() (p *TreePath, c *TreeViewColumn) {
 
 	if path != nil {
 		p = &TreePath{path}
-		runtime.SetFinalizer(p, (*TreePath).free)
+		runtime.SetFinalizer(p, func(v *TreePath) { glib.FinalizerStrategy(v.free) })
 	}
 
 	if col != nil {
@@ -530,7 +528,7 @@ func (v *TreeView) IsBlankAtPos(x, y int) (*TreePath, *TreeViewColumn, int, int,
 
 	if cpath != nil {
 		path = &TreePath{cpath}
-		runtime.SetFinalizer(path, (*TreePath).free)
+		runtime.SetFinalizer(path, func(v *TreePath) { glib.FinalizerStrategy(v.free) })
 	}
 	if ccol != nil {
 		column = wrapTreeViewColumn(glib.Take(unsafe.Pointer(ccol)))
@@ -630,7 +628,7 @@ func (v *TreeView) GetDragDestRow() (path *TreePath, pos TreeViewDropPosition) {
 
 	if cpath != nil {
 		path = &TreePath{cpath}
-		runtime.SetFinalizer(path, (*TreePath).free)
+		runtime.SetFinalizer(path, func(v *TreePath) { glib.FinalizerStrategy(v.free) })
 	}
 
 	return
@@ -650,7 +648,7 @@ func (v *TreeView) GetDestRowAtPos(dragX, dragY int) (path *TreePath, pos TreeVi
 
 	if cpath != nil {
 		path = &TreePath{cpath}
-		runtime.SetFinalizer(path, (*TreePath).free)
+		runtime.SetFinalizer(path, func(v *TreePath) { glib.FinalizerStrategy(v.free) })
 	}
 
 	return

--- a/gtk/widget.go
+++ b/gtk/widget.go
@@ -914,7 +914,7 @@ func requisitionFromNative(requisitionNative *C.GtkRequisition) (*Requisition, e
 	if requisition == nil {
 		return nil, nilPtrErr
 	}
-	runtime.SetFinalizer(requisition, (*Requisition).free)
+	runtime.SetFinalizer(requisition, func(l *Requisition) { glib.FinalizerStrategy(l.free) })
 	return requisition, nil
 }
 

--- a/gtk/window.go
+++ b/gtk/window.go
@@ -653,9 +653,7 @@ func WindowListToplevels() *glib.List {
 	glist.DataWrapper(func(ptr unsafe.Pointer) interface{} {
 		return wrapWindow(glib.Take(ptr))
 	})
-	runtime.SetFinalizer(glist, func(l *glib.List) {
-		l.Free()
-	})
+	runtime.SetFinalizer(glist, func(v *glib.List) { glib.FinalizerStrategy(v.Free) })
 	return glist
 }
 
@@ -670,9 +668,7 @@ func WindowGetDefaultIconList() *glib.List {
 	glist.DataWrapper(func(ptr unsafe.Pointer) interface{} {
 		return &gdk.Pixbuf{glib.Take(ptr)}
 	})
-	runtime.SetFinalizer(glist, func(l *glib.List) {
-		l.Free()
-	})
+	runtime.SetFinalizer(glist, func(v *glib.List) { glib.FinalizerStrategy(v.Free) })
 	return glist
 }
 
@@ -687,9 +683,7 @@ func (v *Window) GetIconList() *glib.List {
 	glist.DataWrapper(func(ptr unsafe.Pointer) interface{} {
 		return &gdk.Pixbuf{glib.Take(ptr)}
 	})
-	runtime.SetFinalizer(glist, func(l *glib.List) {
-		l.Free()
-	})
+	runtime.SetFinalizer(glist, func(v *glib.List) { glib.FinalizerStrategy(v.Free) })
 	return glist
 }
 

--- a/gtk/windowgroup.go
+++ b/gtk/windowgroup.go
@@ -83,9 +83,7 @@ func (v *WindowGroup) ListWindows() *glib.List {
 	glist.DataWrapper(func(ptr unsafe.Pointer) interface{} {
 		return wrapWindow(glib.Take(ptr))
 	})
-	runtime.SetFinalizer(glist, func(l *glib.List) {
-		l.Free()
-	})
+	runtime.SetFinalizer(glist, func(l *glib.List) { glib.FinalizerStrategy(l.Free) })
 	return glist
 }
 

--- a/pango/pango-layout.go
+++ b/pango/pango-layout.go
@@ -312,7 +312,7 @@ func (v *Layout) GetTabs() (*TabArray, error) {
 		return nil, nilPtrErr
 	}
 	ta := wrapTabArray(c)
-	runtime.SetFinalizer(ta, (*TabArray).free)
+	runtime.SetFinalizer(ta, func(v *TabArray) { glib.FinalizerStrategy(v.free) })
 	return ta, nil
 }
 
@@ -359,7 +359,7 @@ func TabArrayNew(initialSize int, positionsInPixels bool) *TabArray {
 	c := C.pango_tab_array_new(C.gint(initialSize), gbool(positionsInPixels))
 
 	tabArray := new(TabArray)
-	runtime.SetFinalizer(tabArray, (*TabArray).free)
+	runtime.SetFinalizer(tabArray, func(v *TabArray) { glib.FinalizerStrategy(v.free) })
 	tabArray.pangoTabArray = (*C.PangoTabArray)(c)
 	return tabArray
 }
@@ -369,7 +369,7 @@ func TabArrayNew(initialSize int, positionsInPixels bool) *TabArray {
 // 	c := C.pango_tab_array_new_with_positions(C.gint(size), gbool(positionsInPixels), ...)
 
 // 	tabArray := new(TabArray)
-//	runtime.SetFinalizer(e, (*TabArray).free)
+//	runtime.SetFinalizer(e, func(v *TabArray) { glib.FinalizerStrategy(v.free) })
 // 	tabArray.pangoTabArray = (*C.PangoTabArray)(c)
 // 	return tabArray
 // }
@@ -381,7 +381,7 @@ func (v *TabArray) Copy() (*TabArray, error) {
 		return nil, nilPtrErr
 	}
 	ta := wrapTabArray(c)
-	runtime.SetFinalizer(ta, (*TabArray).free)
+	runtime.SetFinalizer(ta, func(v *TabArray) { glib.FinalizerStrategy(v.free) })
 	return ta, nil
 }
 


### PR DESCRIPTION
This PR adds the necessary machinery for making it possible for clients to avoid the problem in #810. The idea is to add a global `FinalizerStrategy` variable which by default will only call the function directly. But a client having problems with the UI thread can use this variable to hook in to the strategy and do something else during the finalization process.