### PR TITLE
Use glib FinalizerStrategy in all places where List and SList are freed

### DIFF
--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -1001,8 +1001,15 @@ func (v *DisplayManager) ListDisplays() *[]Display {
 	if clist == nil {
 		return nil
 	}
+
 	dlist := glib.WrapSList(uintptr(unsafe.Pointer(clist)))
-	defer dlist.Free()
+	if dlist == nil {
+		return nil
+	}
+
+	runtime.SetFinalizer(dlist, func(dlist *glib.SList) {
+		glib.FinalizerStrategy(dlist.Free)
+	})
 
 	var displays = make([]Display, 0, dlist.Length())
 	for ; dlist.DataRaw() != nil; dlist = dlist.Next() {

--- a/gdk/pixbuf_since_2_2.go
+++ b/gdk/pixbuf_since_2_2.go
@@ -8,6 +8,7 @@ package gdk
 // #include "pixbuf.go.h"
 import "C"
 import (
+	"runtime"
 	"unsafe"
 
 	"github.com/gotk3/gotk3/glib"
@@ -40,7 +41,9 @@ func PixbufGetFormats() []*PixbufFormat {
 	}
 
 	// "The structures themselves are owned by GdkPixbuf". Free the list only.
-	defer formats.Free()
+	runtime.SetFinalizer(formats, func(formats *glib.SList) {
+		glib.FinalizerStrategy(formats.Free)
+	})
 
 	ret := make([]*PixbufFormat, 0, formats.Length())
 	formats.Foreach(func(item interface{}) {

--- a/glib/list.go
+++ b/glib/list.go
@@ -5,6 +5,7 @@ package glib
 // #include "glib.go.h"
 import "C"
 import (
+	"runtime"
 	"unsafe"
 )
 
@@ -168,7 +169,9 @@ func (v *List) Foreach(fn func(item interface{})) {
 // list.Free() sequentially.
 func (v *List) FreeFull(fn func(item interface{})) {
 	v.Foreach(fn)
-	v.Free()
+	runtime.SetFinalizer(v, func(v *List) {
+		FinalizerStrategy(v.Free)
+	})
 }
 
 // CompareDataFunc is a representation of GCompareDataFunc

--- a/gtk/gtk_since_3_12.go
+++ b/gtk/gtk_since_3_12.go
@@ -322,7 +322,9 @@ func (fb *FlowBox) GetSelectedChildren() (rv []*FlowBoxChild) {
 		rv = append(rv, o)
 	}
 	// We got a transfer container, so we must free the list.
-	list.Free()
+	runtime.SetFinalizer(list, func(list *glib.List) {
+		glib.FinalizerStrategy(list.Free)
+	})
 
 	return
 }

--- a/gtk/icon_view.go
+++ b/gtk/icon_view.go
@@ -330,10 +330,10 @@ func (v *IconView) GetSelectedItems() *glib.List {
 	glist.DataWrapper(func(ptr unsafe.Pointer) interface{} {
 		return &TreePath{(*C.GtkTreePath)(ptr)}
 	})
-	runtime.SetFinalizer(glist, func(glist *glib.List) {
-		glib.FinalizerStrategy(func() {
-			glist.FreeFull(func(item interface{}) {
-				path := item.(*TreePath)
+
+	glist.FreeFull(func(item interface{}) {
+		runtime.SetFinalizer(item, func(path *TreePath) {
+			glib.FinalizerStrategy(func() {
 				C.gtk_tree_path_free(path.GtkTreePath)
 			})
 		})

--- a/gtk/print.go
+++ b/gtk/print.go
@@ -541,10 +541,9 @@ func PaperSizeGetPaperSizes(includeCustom bool) *glib.List {
 		return &PaperSize{(*C.GtkPaperSize)(ptr)}
 	})
 
-	runtime.SetFinalizer(glist, func(glist *glib.List) {
-		glib.FinalizerStrategy(func() {
-			glist.FreeFull(func(item interface{}) {
-				ps := item.(*PaperSize)
+	glist.FreeFull(func(item interface{}) {
+		runtime.SetFinalizer(item, func(ps *PaperSize) {
+			glib.FinalizerStrategy(func() {
 				C.gtk_paper_size_free(ps.GtkPaperSize)
 			})
 		})

--- a/pango/pango-attributes.go
+++ b/pango/pango-attributes.go
@@ -22,6 +22,7 @@ package pango
 // #include "pango.go.h"
 import "C"
 import (
+	"runtime"
 	"unsafe"
 
 	"github.com/gotk3/gotk3/glib"
@@ -142,7 +143,9 @@ func (v *AttrList) GetAttributes() (*glib.SList, error) {
 		return nil, nilPtrErr
 	}
 
-	defer list.Free()
+	runtime.SetFinalizer(list, func(list *glib.SList) {
+		glib.FinalizerStrategy(list.Free)
+	})
 
 	list.DataWrapper(func(ptr unsafe.Pointer) interface{} {
 		return &Attribute{(*C.PangoAttribute)(ptr)}


### PR DESCRIPTION
This PR uses the glib FinalizerStrategy to free used list and slit. This is intended to be added as a continuation of the solution to fix the problem described in #810.