### PR TITLE
#826 merging correction.

### DIFF
--- a/glib/gbinding.go
+++ b/glib/gbinding.go
@@ -59,16 +59,6 @@ func (v *Binding) Unbind() {
 	C.g_binding_unbind(v.native())
 }
 
-// Retrieves the GObject instance used as the source of the binding
-func (v *Binding) GetSource() *Object {
-// 	obj := C.g_binding_get_source(v.native())
-	obj := C.g_binding_dup_source(v.native())
-	if obj == nil {
-		return nil
-	}
-	return wrapObject(unsafe.Pointer(obj))
-}
-
 // Retrieves the name of the property of “target” used as the target of
 // the binding.
 func (v *Binding) GetTargetProperty() string {


### PR DESCRIPTION
As explained here #830, #826 should not have been merged.
#### This PR corrects the added section.
#### ~~Only in case it is not possible to go back (reversed).~~

Edit: I've tried to reverse #826 but without success, i think it's because the [Merge branch 'master' into Update-glib-binding>2.66](https://github.com/gotk3/gotk3/commit/46994fb89f0c40d273e49c7c48e204aef3769784) is disabling this ability.

So, this pr simply removes this part of the code (below) added with the merge of #826, because it is already present (in corrected version) in the file [gbinding_since_2_68.go](https://github.com/gotk3/gotk3/blob/master/glib/gbinding_since_2_68.go)

```go
// Retrieves the GObject instance used as the source of the binding
func (v *Binding) GetSource() *Object {
// 	obj := C.g_binding_get_source(v.native())
	obj := C.g_binding_dup_source(v.native())
	if obj == nil {
		return nil
	}
	return wrapObject(unsafe.Pointer(obj))
}
```