### PR TITLE
adjust function signatures in tests

### DIFF
--- a/glib/glib_test.go
+++ b/glib/glib_test.go
@@ -34,12 +34,11 @@ func TestConnectNotifySignal(t *testing.T) {
 		gtk.MainQuit()
 	})
 
-	glib.IdleAdd(func(s string) bool {
-		t.Log(s)
+	glib.IdleAdd(func() bool {
 		spacing++
 		box.SetSpacing(spacing)
 		return true
-	}, "IdleAdd executed")
+	})
 
 	gtk.Main()
 }
@@ -48,11 +47,10 @@ func TestConnectNotifySignal(t *testing.T) {
 func TestTimeoutAdd(t *testing.T) {
 	runtime.LockOSThread()
 
-	glib.TimeoutAdd(2500, func(s string) bool {
-		t.Log(s)
+	glib.TimeoutAdd(2500, func() bool {
 		gtk.MainQuit()
 		return false
-	}, "TimeoutAdd executed")
+	})
 
 	gtk.Main()
 }

--- a/gtk/print_test.go
+++ b/gtk/print_test.go
@@ -49,7 +49,7 @@ func TestPrintSettings(t *testing.T) {
 	settings.SetInt("Key4", 2)
 
 	settings.ForEach(func(key, value string) {
-	}, 0)
+	})
 }
 
 // TestPrintContext tests creating and manipulating PrintContext


### PR DESCRIPTION
We adjust the signatures of the `IdleAdd()`, `TimeoutAdd()` and `ForEach()` function calls used in tests to match the actual implementation, fixing `go test` runs.

Closes #844.