### PR TITLE
Added FontChooserDialog to gotk3

### DIFF
--- a/gtk/font_chooser.go
+++ b/gtk/font_chooser.go
@@ -214,6 +214,61 @@ func (v *FontButton) GetTitle() string {
 }
 
 /*
+ * GtkFontChooserDialog
+ */
+
+// FontChooserDialog is a representation of GTK's GtkFontChooserDialog.
+type FontChooserDialog struct {
+	Dialog
+
+	// Interfaces
+	FontChooser
+}
+
+// native returns a pointer to the underlying GtkFontChooserDialog.
+func (v *FontChooserDialog) native() *C.GtkFontChooserDialog {
+	if v == nil || v.GObject == nil {
+		return nil
+	}
+
+	p := unsafe.Pointer(v.GObject)
+	return C.toGtkFontChooserDialog(p)
+}
+
+func marshalFontChooserDialog(p uintptr) (interface{}, error) {
+	c := C.g_value_get_object((*C.GValue)(unsafe.Pointer(p)))
+	return wrapFontChooserDialog(glib.Take(unsafe.Pointer(c))), nil
+}
+
+func wrapFontChooserDialog(obj *glib.Object) *FontChooserDialog {
+	if obj == nil {
+		return nil
+	}
+
+	dialog := wrapDialog(obj)
+	cc := wrapFontChooser(obj)
+	return &FontChooserDialog{*dialog, *cc}
+}
+
+// FontChooserDialogNew() is a wrapper around gtk_font_chooser_dialog_new().
+func FontChooserDialogNew(title string, parent IWindow) (*FontChooserDialog, error) {
+
+	cstr := C.CString(title)
+	defer C.free(unsafe.Pointer(cstr))
+
+	var w *C.GtkWindow = nil
+	if parent != nil {
+		w = parent.toWindow()
+	}
+
+	c := C.gtk_font_chooser_dialog_new((*C.gchar)(cstr), w)
+	if c == nil {
+		return nil, nilPtrErr
+	}
+	return wrapFontChooserDialog(glib.Take(unsafe.Pointer(c))), nil
+}
+
+/*
  * GtkFontChooserWidget
  */
 

--- a/gtk/gtk.go.h
+++ b/gtk/gtk.go.h
@@ -59,6 +59,10 @@ static GtkColorChooserDialog *toGtkColorChooserDialog(void *p) {
   return (GTK_COLOR_CHOOSER_DIALOG(p));
 }
 
+static GtkFontChooserDialog *toGtkFontChooserDialog(void *p) {
+  return (GTK_FONT_CHOOSER_DIALOG(p));
+}
+
 static GtkDrawingArea *toGtkDrawingArea(void *p) {
   return (GTK_DRAWING_AREA(p));
 }


### PR DESCRIPTION
Example usage:
```
		d, _ := gtk.FontChooserDialogNew("Choose Font", win)
		d.Run()
		fmt.Println("choosen font:", d.GetFont())
		d.Destroy()
```