### PR TITLE
Fixed typo for GtkColorChooserDialog native comment.

### DIFF
--- a/gtk/color_chooser.go
+++ b/gtk/color_chooser.go
@@ -119,7 +119,7 @@ type ColorChooserDialog struct {
 	ColorChooser
 }
 
-// native returns a pointer to the underlying GtkColorChooserButton.
+// native returns a pointer to the underlying GtkColorChooserDialog.
 func (v *ColorChooserDialog) native() *C.GtkColorChooserDialog {
 	if v == nil || v.GObject == nil {
 		return nil


### PR DESCRIPTION
Think this is a typo, unless I'm reading the code wrong.