### PR TITLE
Update Binding build tags to only build on later versions of Glib. 

### DIFF
--- a/glib/gbinding_since_2_68.go
+++ b/glib/gbinding_since_2_68.go
@@ -1,4 +1,5 @@
-// +build !glib_deprecated
+//go:build !glib_deprecated && !glib_2_40 && !glib_2_42 && !glib_2_44 && !glib_2_46 && !glib_2_48 && !glib_2_50 && !glib_2_52 && !glib_2_54 && !glib_2_56 && !glib_2_58 && !glib_2_60 && !glib_2_62 && !glib_2_64 && !glib_2_66
+// +build !glib_deprecated,!glib_2_40,!glib_2_42,!glib_2_44,!glib_2_46,!glib_2_48,!glib_2_50,!glib_2_52,!glib_2_54,!glib_2_56,!glib_2_58,!glib_2_60,!glib_2_62,!glib_2_64,!glib_2_66
 
 package glib
 


### PR DESCRIPTION
The current HEAD doesn't build on older Glib versions. This commit simply adds the tags where not to build it, following previous formats.

The only difference is that it also supplies the build tags in both the old and new format, something which is recommended for libraries that will be used from many different Golang versions.
