### PR TITLE
Implement gtk_widget_unset_state_flags and gtk_widget_get_state_flags

### DIFF
--- a/gtk/widget.go
+++ b/gtk/widget.go
@@ -855,9 +855,13 @@ func (v *Widget) SetStateFlags(stateFlags StateFlags, clear bool) {
 	C.gtk_widget_set_state_flags(v.native(), C.GtkStateFlags(stateFlags), gbool(clear))
 }
 
-// TODO:
-// gtk_widget_unset_state_flags().
-// gtk_widget_get_state_flags().
+func (v *Widget) UnsetStateFlags(stateFlags StateFlags) {
+	C.gtk_widget_unset_state_flags(v.native(), C.GtkStateFlags(stateFlags))
+}
+
+func (v *Widget) GetStateFlags() StateFlags {
+	return StateFlags(C.gtk_widget_get_state_flags(v.native()))
+}
 
 // GetWindow is a wrapper around gtk_widget_get_window().
 func (v *Widget) GetWindow() (*gdk.Window, error) {


### PR DESCRIPTION
Implemented:
- gtk_widget_unset_state_flags as Widget.UnsetStateFlags(StateFlags)
- gtk_widget_get_state_flags as GetStateFlags() StateFlags

Tested on go1.21.6