### PR TITLE
Add missing parameter in test Emit call

### DIFF
--- a/gtk/gtk_test.go
+++ b/gtk/gtk_test.go
@@ -870,7 +870,7 @@ func TestBuilder(t *testing.T) {
 		},
 	})
 
-	go button.Emit("clicked")
+	go button.Emit("clicked", glib.TYPE_STRING)
 
 	select {
 	case <-done:


### PR DESCRIPTION
This PR adds the missing type parameter to an `Emit()` call in `gtk_test.go` causing tests to fail.

Closes #917