### PR TITLE
Implementing gdk_event_get_scancode

### DIFF
--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -1272,6 +1272,10 @@ func (v *Event) free() {
 	C.gdk_event_free(v.native())
 }
 
+func (v *Event) ScanCode() int {
+    return int(C.gdk_event_get_scancode(v.native()))
+}
+
 /*
  * GdkEventButton
  */


### PR DESCRIPTION
This absolutely feels like the wrong place to me, however according to the GTK docs, it should be on the event (https://docs.gtk.org/gdk3/method.Event.get_scancode.html) rather than the EventKey. In my testing this is always 0, however I think this is a characteristic of my environment (Debian 12 + X11) rather than this being broken

Fixes: https://github.com/gotk3/gotk3/issues/919