### PR TITLE
Add marshaler for CssProvider

### DIFF
--- a/gtk/gtk_test.go
+++ b/gtk/gtk_test.go
@@ -905,3 +905,27 @@ func TestTextTagEvent(t *testing.T) {
 	}
 
 }
+
+func TestCssProviderParsingErrorEvent(t *testing.T) {
+	css, err := CssProviderNew()
+	if err != nil {
+		t.Error("could not create CSS provider")
+	}
+
+	done := make(chan bool)
+
+	css.Connect("parsing-error",
+		// The first argument must be a CssProvider
+		func(css *CssProvider) {
+			done <- true
+		},
+	)
+
+	go css.LoadFromData(";")
+
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Error("Failed to call callback")
+	}
+}


### PR DESCRIPTION
Noticed the handler for the [CssProvider::parsing-error](https://docs.gtk.org/gtk3/signal.CssProvider.parsing-error.html) signal was being given a `*glib.Object` as its first argument, instead of a `*gtk.CssProvider`.

The comment changes must have been `gofmt`...