### PR TITLE
Improving SignalNewV wrapper

### DIFF
--- a/glib/glib.go
+++ b/glib/glib.go
@@ -1414,7 +1414,7 @@ func SignalNewV(
 		sliceOfGTypes = append(sliceOfGTypes, C.GType(paramType))
 	}
 
-	signalId := C._g_signal_newv((*C.gchar)(cstr), C.gsize(returnType), C.guint(nParams), &sliceOfGTypes[0])
+	signalId := C._g_signal_newv((*C.gchar)(cstr), C.GType(returnType), C.guint(nParams), &sliceOfGTypes[0])
 
 	if signalId == 0 {
 		return nil, fmt.Errorf("invalid signal name: %s", signalName)

--- a/glib/glib.go.h
+++ b/glib/glib.go.h
@@ -162,7 +162,7 @@ static inline guint _g_signal_new(const gchar *name) {
 
 static inline guint _g_signal_newv(const gchar *name, const GType return_type,
                                    const guint n_params, GType *const param_types) {
-  return g_signal_newv(name, G_TYPE_OBJECT, G_SIGNAL_RUN_FIRST | G_SIGNAL_ACTION,
+  return g_signal_newv(name, G_TYPE_OBJECT, G_SIGNAL_ACTION,
                        NULL, NULL, NULL, g_cclosure_marshal_VOID__POINTER,
                        return_type, n_params, param_types);
 }


### PR DESCRIPTION
Basically this PR improves the wrapper `SignalNewV` for C function `g_signal_newv`, I was trying to compile a gotk3 application with Ubuntu 20.04 (that uses glib2 < 2.68) so I had to use the tag `glib_2_66` when building, after the application compiled, then, this [issue](https://gitlab.gnome.org/GNOME/glib/-/issues/513) appeared, I was unable to create signals with return values using the `SignalNewV` wrapper because it uses `G_SIGNAL_RUN_FIRST` for the `signal_flags` parameter.

Based in the [signal flags docs](https://docs.gtk.org/gobject/flags.SignalFlags.html), the more accurate flag for custom signals that are emitted programmatically would be [`G_SIGNAL_ACTION`](https://docs.gtk.org/gobject/flags.SignalFlags.html#action) so this PR improves the wrapper to only use that flag.