### PR TITLE
fixed toGoStringArray segmentation fault

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -314,7 +314,7 @@ func ucharString(guchar *C.guchar) string {
 // nextgcharptr increments gcharptr by 1. Hopefully, this could be inlined by
 // the Go compiler.
 func nextgcharptr(gcharptr **C.gchar) **C.gchar {
-	return (**C.gchar)(unsafe.Pointer(uintptr(unsafe.Pointer(gcharptr)) + 1))
+	return (**C.gchar)(unsafe.Pointer(uintptr(unsafe.Pointer(gcharptr)) + unsafe.Sizeof(*gcharptr)))
 }
 
 func goString(cstr *C.gchar) string {


### PR DESCRIPTION
The current implementation of function toGoStringArray in gtk/gtk.go causes a segmentation fault, because it relies on nextgcharptr to iterate over gchar* strings in the array.
However, the function nextgcharptr does not increase the pointer by the size of gchar*. Instead it increases it by one byte, leading to misalignment and segmentation fault when using the function toGoStringArray.

Two methods use this function and therefore cause a segmentation fault:
- GtkSelectionData::GetURIs
- GtkScaleButton::SetIcons